### PR TITLE
[GUVNOR-3320] Implement test for workbench readiness probe in Openshift

### DIFF
--- a/framework-cloud/framework-cloud-common/src/main/java/org/kie/cloud/common/provider/WorkbenchClientProvider.java
+++ b/framework-cloud/framework-cloud-common/src/main/java/org/kie/cloud/common/provider/WorkbenchClientProvider.java
@@ -49,5 +49,9 @@ public class WorkbenchClientProvider {
     public void deployProject(String repoName, String projectName) {
         workbenchClient.deployProject(repoName, projectName);
     }
+
+    public WorkbenchClient getWorkbenchClient() {
+        return workbenchClient;
+    }
 }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ReadinessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ReadinessProbeIntegrationTest.java
@@ -163,7 +163,7 @@ public class ReadinessProbeIntegrationTest {
             logger.debug("Login page content contains {} characters", responseContent.length());
             httpURLConnection.disconnect();
 
-            Assertions.assertThat(responseContent.contains(WORKBENCH_LOGIN_SCREEN_TEXT)).isTrue();
+            Assertions.assertThat(responseContent).contains(WORKBENCH_LOGIN_SCREEN_TEXT);
 
         } catch (IOException e) {
             Assertions.fail("Unable to load workbench login screen");

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ReadinessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ReadinessProbeIntegrationTest.java
@@ -166,7 +166,7 @@ public class ReadinessProbeIntegrationTest {
             Assertions.assertThat(responseContent).contains(WORKBENCH_LOGIN_SCREEN_TEXT);
 
         } catch (IOException e) {
-            Assertions.fail("Unable to load workbench login screen");
+            Assertions.fail("Unable to load workbench login screen", e);
         }
     }
 }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ReadinessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ReadinessProbeIntegrationTest.java
@@ -1,13 +1,19 @@
 package org.kie.cloud.integrationtests.smoke;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
+import org.guvnor.rest.client.OrganizationalUnit;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.junit.After;
 import org.junit.Before;
@@ -27,6 +33,8 @@ import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.controller.client.KieServerMgmtControllerClient;
 import org.kie.server.integrationtests.shared.filter.Authenticator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ReadinessProbeIntegrationTest {
 
@@ -42,6 +50,8 @@ public class ReadinessProbeIntegrationTest {
 
     private static final String GIT_REPOSITORY_NAME = "myGitRepo";
 
+    private static final String WORKBENCH_LOGIN_SCREEN_TEXT = "Sign In";
+
     private DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactory.getInstance();
     private WorkbenchWithKieServerScenario workbenchWithKieServerScenario;
     private Client httpKieServerClient;
@@ -50,6 +60,8 @@ public class ReadinessProbeIntegrationTest {
     private KieServerMgmtControllerClient kieControllerClient;
 
     private GitProvider gitProvider;
+
+    private static final Logger logger = LoggerFactory.getLogger(ReadinessProbeIntegrationTest.class);
 
     @Before
     public void setUp() {
@@ -86,6 +98,29 @@ public class ReadinessProbeIntegrationTest {
     }
 
     @Test
+    public void testWorkbenchReadinessProbe() {
+        logger.debug("Check that workbench login screen is available");
+        Assertions.assertThat(isBCLoginScreenAvailable()).isTrue();
+        logger.debug("Check that workbench REST is available");
+        Collection<OrganizationalUnit> organizationalUnits = workbenchClientProvider.getWorkbenchClient().getOrganizationalUnits();
+        Assertions.assertThat(organizationalUnits.stream().anyMatch(x -> x.getName().equals(ORGANIZATION_UNIT_NAME))).isTrue();
+
+        logger.debug("Scale workbench to 0");
+        workbenchWithKieServerScenario.getWorkbenchDeployment().scale(0);
+        workbenchWithKieServerScenario.getWorkbenchDeployment().waitForScale();
+        logger.debug("Scale workbench to 1");
+        workbenchWithKieServerScenario.getWorkbenchDeployment().scale(1);
+        workbenchWithKieServerScenario.getWorkbenchDeployment().waitForScale();
+
+        logger.debug("Check that workbench login screen is available");
+        Assertions.assertThat(isBCLoginScreenAvailable()).isTrue();
+        logger.debug("Check that workbench REST is available");
+        workbenchClientProvider.createOrganizationalUnit(ORGANIZATION_UNIT_NAME, workbenchWithKieServerScenario.getWorkbenchDeployment().getUsername());
+        organizationalUnits = workbenchClientProvider.getWorkbenchClient().getOrganizationalUnits();
+        Assertions.assertThat(organizationalUnits.stream().anyMatch(x -> x.getName().equals(ORGANIZATION_UNIT_NAME))).isTrue();
+    }
+
+    @Test
     public void testKieServerReadinessProbe() {
         Marshaller marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.JAXB, this.getClass().getClassLoader());
 
@@ -112,5 +147,34 @@ public class ReadinessProbeIntegrationTest {
             }
         }
         Assertions.fail("Timeout while waiting for OpenShift router to establish connection to Kie server.");
+    }
+
+    private boolean isBCLoginScreenAvailable() {
+        URL url = workbenchWithKieServerScenario.getWorkbenchDeployment().getUrl();
+        HttpURLConnection httpURLConnection;
+        try {
+            httpURLConnection = (HttpURLConnection) url.openConnection();
+            logger.debug("Connecting to business central login screen");
+            httpURLConnection.connect();
+            logger.debug("Http response code is {}", httpURLConnection.getResponseCode());
+            if (httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                logger.debug("Connection to business central login screen failed with code {}", httpURLConnection.getResponseCode());
+                return false;
+            }
+
+            logger.debug("Reading login page content");
+            String responseContent = IOUtils.toString(httpURLConnection.getInputStream());
+            logger.debug("Login page content contains {} characters", responseContent.length());
+            httpURLConnection.disconnect();
+
+            if (!responseContent.contains(WORKBENCH_LOGIN_SCREEN_TEXT)) {
+                logger.debug("Wrong content of workbench login screen");
+                return false;
+            }
+
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Implement test for workbench readiness probe in Openshift.

1.Run container with KIE workbench in Openshift
2. Wait until workbench container is ready to accept requests (readiness probe is set to true)
3. Check that workbench login screen is available
4. Check that workbench REST API is able to process requests
5. Scale workbench to zero
6. Scale workbench back to one
7. Wait until workbench container is ready to accept requests (readiness probe is set to true)
8. Check that workbench login screen is available
9. Check that workbench REST API is able to process requests