### PR TITLE
Separate framework constants to specific classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,22 @@ The following table lists all currently required and supported parameters:
 
 ### OpenShift properties
 
-| \<specific-params\>  | Default value  |  Meaning                                              |
-| -------------------- | ------ | ------------------------------------------------------------- |
-| openshift.master.url |        | URL pointing to OpenShift, for example https://127.0.0.1:8443 |
-| openshift.username   |  user  | Username for logging into OpenShift                           |
-| openshift.password   | redhat | Password for logging into OpenShift                           |
-| kie.image.streams    |        | URL pointing to file with image stream definitions            |
+Can be found in framework-openshift, class org.kie.cloud.openshift.constants.OpenShiftConstants
+
+| \<specific-params\>  | Default value  |  Meaning                                                      |
+| -------------------- | -------------- | ------------------------------------------------------------- |
+| openshift.master.url |                | URL pointing to OpenShift, for example https://127.0.0.1:8443 |
+| openshift.username   | user           | Username for logging into OpenShift                           |
+| openshift.password   | redhat         | Password for logging into OpenShift                           |
+| kie.image.streams    |                | URL pointing to file with image stream definitions            |
+| kie.app.secret       | \<GitHub URL\> | URL pointing to file with secrets                             |
+| kie.app.template     | \<GitHub URL\> | URL pointing to file with Kie deployments template            |
+| kie.app.name         | myapp          | Application name used as prefix for Kie deployments           |
 
 ### GIT provider properties
 
-Chooose one GIT provider
+Choose one GIT provider.
+Can be found in framework-git, class org.kie.cloud.git.constants.GitConstants
 
 #### GitLab
 
@@ -41,3 +47,16 @@ Chooose one GIT provider
 | git.provider        | GitHub |                                       |
 | github.username     |        | Username for logging into GitHub      |
 | github.password     |        | Password for logging into GitHub      |
+
+### Deployment properties
+
+Properties required for configuration of specific deployments.
+
+Can be found in framework-cloud-api, class org.kie.cloud.api.deployment.constants.DeploymentConstants
+
+| \<specific-params\>    | Default value   |  Meaning             |
+| ---------------------- | --------------- | -------------------- |
+| org.kie.server.user    | yoda            | Kie server user      |
+| org.kie.server.pwd     | usetheforce123@ | Kie server password  |
+| org.kie.workbench.user | adminUser       | Workbench user       |
+| org.kie.workbench.pwd  | adminUser1!     | Workbench password   |

--- a/framework-cloud/framework-cloud-api/pom.xml
+++ b/framework-cloud/framework-cloud-api/pom.xml
@@ -14,4 +14,12 @@
 
   <name>KIE :: Cloud :: API</name>
   <description>Cloud API for Kie integration tests</description>
+
+  <dependencies>
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/constants/Constants.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/constants/Constants.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.cloud.api.constants;
+
+public interface Constants {
+}

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/constants/TestInfoPrinter.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/constants/TestInfoPrinter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.cloud.api.constants;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.TreeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestInfoPrinter {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestInfoPrinter.class);
+
+    public static void printTestConstants() {
+        logger.info("--------- Initializing Constants ----------");
+
+        ServiceLoader<Constants> serviceLoader = ServiceLoader.load(Constants.class);
+
+        TreeMap<String, String> params = new TreeMap<String, String>();
+        int maxKeyLength = 0;
+        for (Constants constants : serviceLoader) {
+            for (Field f : constants.getClass().getDeclaredFields()) {
+                if (String.class.isAssignableFrom(f.getType())) {
+                    try {
+                        String paramName = (String) f.get(null);
+                        String paramValue = System.getProperty(paramName);
+                        maxKeyLength = Math.max(maxKeyLength, paramName.length());
+                        params.put(paramName, paramValue);
+                    } catch (IllegalAccessException ex) {
+                        logger.error("Cannot read field '{}'.", f.getName(), ex);
+                    }
+                }
+            }
+        }
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            String paramName = entry.getKey();
+            String value = entry.getValue();
+
+            logger.info("{} = {}",
+                    String.format("%" + maxKeyLength + "s", paramName),
+                    value
+            );
+        }
+
+        logger.info("-------------------------------------------");
+    }
+}

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.cloud.api.deployment.constants;
+
+import org.kie.cloud.api.constants.Constants;
+import org.kie.cloud.api.constants.TestInfoPrinter;
+
+public class DeploymentConstants implements Constants {
+
+    static {
+        TestInfoPrinter.printTestConstants();
+    }
+
+    public static final String KIE_SERVER_USER = "org.kie.server.user";
+    public static final String KIE_SERVER_PASSWORD = "org.kie.server.pwd";
+
+    public static final String WORKBENCH_USER = "org.kie.workbench.user";
+    public static final String WORKBENCH_PASSWORD = "org.kie.workbench.pwd";
+
+    public static String getKieServerUser() {
+        return System.getProperty(KIE_SERVER_USER);
+    }
+
+    public static String getKieServerPassword() {
+        return System.getProperty(KIE_SERVER_PASSWORD);
+    }
+
+    public static String getWorkbenchUser() {
+        return System.getProperty(WORKBENCH_USER);
+    }
+
+    public static String getWorkbenchPassword() {
+        return System.getProperty(WORKBENCH_PASSWORD);
+    }
+}

--- a/framework-cloud/framework-cloud-api/src/main/resources/META-INF/services/org.kie.cloud.api.constants.Constants
+++ b/framework-cloud/framework-cloud-api/src/main/resources/META-INF/services/org.kie.cloud.api.constants.Constants
@@ -1,0 +1,1 @@
+org.kie.cloud.api.deployment.constants.DeploymentConstants

--- a/framework-cloud/framework-git/pom.xml
+++ b/framework-cloud/framework-git/pom.xml
@@ -14,6 +14,11 @@
   <description>Various tools for controlling GIT repository</description>
 
   <dependencies>
+    <dependency>
+      <groupId>org.kie.cloud</groupId>
+      <artifactId>framework-cloud-api</artifactId>
+    </dependency>
+
     <!-- GitLab client -->
     <dependency>
       <groupId>org.gitlab</groupId>

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/GitProviderFactory.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/GitProviderFactory.java
@@ -18,6 +18,7 @@ package org.kie.cloud.git;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.kie.cloud.git.constants.GitConstants;
 import org.kie.cloud.git.github.GitHubGitProvider;
 import org.kie.cloud.git.gitlab.GitLabGitProvider;
 
@@ -33,10 +34,10 @@ public class GitProviderFactory {
     private GitProviderFactory() {}
 
     public static GitProvider getGitProvider() {
-        String gitProviderName = System.getProperty(GitProperties.GIT_PROVIDER);
+        String gitProviderName = GitConstants.getGitProvider();
 
         if(gitProviderName == null) {
-            throw new RuntimeException("No GIT provider defined. Please define provider using " + GitProperties.GIT_PROVIDER + " system property.");
+            throw new RuntimeException("No GIT provider defined. Please define provider using " + GitConstants.GIT_PROVIDER + " system property.");
         }
 
         if(!gitProviders.containsKey(gitProviderName)) {

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/constants/GitConstants.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/constants/GitConstants.java
@@ -13,10 +13,11 @@
  * limitations under the License.
 */
 
-package org.kie.cloud.git;
+package org.kie.cloud.git.constants;
 
+import org.kie.cloud.api.constants.Constants;
 
-public class GitProperties {
+public class GitConstants implements Constants {
 
     public static final String GIT_PROVIDER = "git.provider";
 
@@ -26,4 +27,28 @@ public class GitProperties {
 
     public static final String GITHUB_USER = "github.username";
     public static final String GITHUB_PASSWORD = "github.password";
+
+    public static String getGitProvider() {
+        return System.getProperty(GIT_PROVIDER);
+    }
+
+    public static String getGitLabUrl() {
+        return System.getProperty(GITLAB_URL);
+    }
+
+    public static String getGitLabUser() {
+        return System.getProperty(GITLAB_USER);
+    }
+
+    public static String getGitLabPassword() {
+        return System.getProperty(GITLAB_PASSWORD);
+    }
+
+    public static String getGitHubUser() {
+        return System.getProperty(GITHUB_USER);
+    }
+
+    public static String getGitHubPassword() {
+        return System.getProperty(GITHUB_PASSWORD);
+    }
 }

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/github/GitHubGitProvider.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/github/GitHubGitProvider.java
@@ -26,13 +26,10 @@ import org.eclipse.jgit.api.RemoteAddCommand;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
-import org.kie.cloud.git.GitProperties;
 import org.kie.cloud.git.GitProvider;
+import org.kie.cloud.git.constants.GitConstants;
 
 public class GitHubGitProvider implements GitProvider {
-
-    private static final String GITHUB_USER = System.getProperty(GitProperties.GITHUB_USER);
-    private static final String GITHUB_PASSWORD = System.getProperty(GitProperties.GITHUB_PASSWORD);
 
     private GitHubClient client;
 
@@ -55,7 +52,7 @@ public class GitHubGitProvider implements GitProvider {
             git.add().addFilepattern(".").call();
             git.commit().setMessage("Initial commit").call();
 
-            CredentialsProvider credentialsProvider = new UsernamePasswordCredentialsProvider(GITHUB_USER, GITHUB_PASSWORD);
+            CredentialsProvider credentialsProvider = new UsernamePasswordCredentialsProvider(GitConstants.getGitHubUser(), GitConstants.getGitHubPassword());
             git.push().setCredentialsProvider(credentialsProvider).setRemote("origin").setPushAll().call();
         } catch (Exception e) {
             throw new RuntimeException("Error while preparing GitHub project " + repositoryName, e);
@@ -65,7 +62,7 @@ public class GitHubGitProvider implements GitProvider {
     @Override
     public void deleteGitRepository(String repositoryName) {
         try {
-            client.delete("/repos/" + GITHUB_USER + "/" + repositoryName);
+            client.delete("/repos/" + GitConstants.getGitHubUser() + "/" + repositoryName);
         } catch (IOException e) {
             throw new RuntimeException("Error while deleting GitHub project " + repositoryName, e);
         }
@@ -75,7 +72,7 @@ public class GitHubGitProvider implements GitProvider {
     public String getRepositoryUrl(String repositoryName) {
         try {
             RepositoryService service = new RepositoryService(client);
-            Repository repository = service.getRepository(GITHUB_USER, repositoryName);
+            Repository repository = service.getRepository(GitConstants.getGitHubUser(), repositoryName);
             return repository.getSvnUrl();
         } catch (IOException e) {
             throw new RuntimeException("Error while retrieving GitHub project URL from " + repositoryName, e);
@@ -85,6 +82,6 @@ public class GitHubGitProvider implements GitProvider {
     @Override
     public void init() {
         client = new GitHubClient();
-        client.setCredentials(GITHUB_USER, GITHUB_PASSWORD);
+        client.setCredentials(GitConstants.getGitHubUser(), GitConstants.getGitHubPassword());
     }
 }

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/gitlab/GitLabGitProvider.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/gitlab/GitLabGitProvider.java
@@ -26,14 +26,10 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.gitlab.api.GitlabAPI;
 import org.gitlab.api.models.GitlabProject;
 import org.gitlab.api.models.GitlabSession;
-import org.kie.cloud.git.GitProperties;
 import org.kie.cloud.git.GitProvider;
+import org.kie.cloud.git.constants.GitConstants;
 
 public class GitLabGitProvider implements GitProvider {
-
-    private static final String GITLAB_URL = System.getProperty(GitProperties.GITLAB_URL);
-    private static final String GITLAB_USER = System.getProperty(GitProperties.GITLAB_USER);
-    private static final String GITLAB_PASSWORD = System.getProperty(GitProperties.GITLAB_PASSWORD);
 
     private GitlabAPI gitLabApi;
 
@@ -51,7 +47,7 @@ public class GitLabGitProvider implements GitProvider {
             git.add().addFilepattern(".").call();
             git.commit().setMessage("Initial commit").call();
 
-            CredentialsProvider credentialsProvider = new UsernamePasswordCredentialsProvider(GITLAB_USER, GITLAB_PASSWORD);
+            CredentialsProvider credentialsProvider = new UsernamePasswordCredentialsProvider(GitConstants.getGitLabUser(), GitConstants.getGitLabPassword());
             git.push().setCredentialsProvider(credentialsProvider).setRemote("origin").setPushAll().call();
         } catch (Exception e) {
             throw new RuntimeException("Error while preparing GitLab project" + repositoryName, e);
@@ -88,9 +84,9 @@ public class GitLabGitProvider implements GitProvider {
     @Override
     public void init() {
         try {
-            GitlabSession session = GitlabAPI.connect(GITLAB_URL, GITLAB_USER, GITLAB_PASSWORD);
+            GitlabSession session = GitlabAPI.connect(GitConstants.getGitLabUrl(), GitConstants.getGitLabUser(), GitConstants.getGitLabPassword());
             String privateToken = session.getPrivateToken();
-            gitLabApi = GitlabAPI.connect(GITLAB_URL, privateToken);
+            gitLabApi = GitlabAPI.connect(GitConstants.getGitLabUrl(), privateToken);
         } catch (IOException e) {
             throw new RuntimeException("Error while initializing GitLab.", e);
         }

--- a/framework-cloud/framework-git/src/main/resources/META-INF/services/org.kie.cloud.api.constants.Constants
+++ b/framework-cloud/framework-git/src/main/resources/META-INF/services/org.kie.cloud.api.constants.Constants
@@ -1,0 +1,1 @@
+org.kie.cloud.git.constants.GitConstants

--- a/framework-cloud/framework-git/src/test/java/org/kie/cloud/git/GitProviderFactoryTest.java
+++ b/framework-cloud/framework-git/src/test/java/org/kie/cloud/git/GitProviderFactoryTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import org.junit.Test;
+import org.kie.cloud.git.constants.GitConstants;
 import org.kie.cloud.git.github.GitHubGitProvider;
 
 public class GitProviderFactoryTest {
@@ -31,24 +32,24 @@ public class GitProviderFactoryTest {
 
     @Test
     public void testGetNotFoundGitProvider() {
-        System.setProperty(GitProperties.GIT_PROVIDER, "not-existing-provider");
+        System.setProperty(GitConstants.GIT_PROVIDER, "not-existing-provider");
 
         try {
             Throwable thrown = catchThrowable(() -> GitProviderFactory.getGitProvider());
             assertThat(thrown).isInstanceOf(RuntimeException.class).hasMessageContaining("GIT provider with name not-existing-provider not found");
         } finally {
-            System.clearProperty(GitProperties.GIT_PROVIDER);
+            System.clearProperty(GitConstants.GIT_PROVIDER);
         }
     }
 
     @Test
     public void testGetGitHubGitProvider() {
-        System.setProperty(GitProperties.GIT_PROVIDER, "GitHub");
+        System.setProperty(GitConstants.GIT_PROVIDER, "GitHub");
 
         try {
             assertThat(GitProviderFactory.getGitProvider()).isInstanceOf(GitHubGitProvider.class);
         } finally {
-            System.clearProperty(GitProperties.GIT_PROVIDER);
+            System.clearProperty(GitConstants.GIT_PROVIDER);
         }
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
@@ -15,159 +15,45 @@
 
 package org.kie.cloud.openshift.constants;
 
-import java.lang.reflect.Field;
-import java.util.Map;
-import java.util.TreeMap;
+import org.kie.cloud.api.constants.Constants;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+public class OpenShiftConstants implements Constants {
 
-public class OpenShiftConstants {
+    public static final String OPENSHIFT_URL = "openshift.master.url";
+    public static final String OPENSHIFT_USER = "openshift.username";
+    public static final String OPENSHIFT_PASSWORD = "openshift.password";
 
-    // Service constants
-    public static final String EAP_DEFAULT_PROTOCOL = "TCP";
-    public static final int EAP_DEFAULT_HTTP_PORT = 8080;
+    public static final String KIE_APP_SECRET = "kie.app.secret";
+    public static final String KIE_IMAGE_STREAMS = "kie.image.streams";
+    public static final String KIE_APP_TEMPLATE = "kie.app.template";
 
-    // Deployment config constants
-    public static final String DEPLOYMENT_TRIGGER_CONFIG_CHANGE = "ConfigChange";
-    public static final long DEPLOYMENT_CONFIG_CREATION_TIMEOUT = 60 * 1000L; // 1 minute
-    public static final String DEPLOYMENT_CONFIG_LABEL = "deploymentConfig";
-
-    // Route constants
-    public static final String CENTRAL_CI_ROUTE_SUFFIX = ".project.openshiftdomain";
-    public static final String ROUTE_REDIRECT_COMPONENT_TYPE = "Service";
-    public static final int ROUTE_REDIRECT_DEFAULT_WEIGHT = 100;
-
-    // Pod constants
-    public static final long DEPLOYMENT_PODS_TERMINATION_TIMEOUT = 10 * 60 * 1000L; // 10 minutes
-    public static final long PODS_START_TO_READY_TIMEOUT = 10 * 60 * 1000L; // 10 minutes
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpenShiftConstants.class);
-
-    static {
-        LOGGER.info("----- Initializing OpenshiftConstants -----");
-    }
-
-    // Default values for local tests
-    private static final StringTestParameter OPENSHIFT_URL = new StringTestParameter("openshift.master.url");
-    private static final StringTestParameter OPENSHIFT_USER = new StringTestParameter("openshift.username");
-    private static final StringTestParameter OPENSHIFT_PASSWORD = new StringTestParameter("openshift.password");
-
-    private static final StringTestParameter KIE_APP_SECRET = new StringTestParameter("kie.app.secret");
-    private static final StringTestParameter KIE_IMAGE_STREAMS = new StringTestParameter("kie.image.streams");
-    private static final StringTestParameter KIE_APP_TEMPLATE = new StringTestParameter("kie.app.template");
-
-    private static final StringTestParameter KIE_SERVER_USER = new StringTestParameter("org.kie.server.user", "yoda");
-    private static final StringTestParameter KIE_SERVER_PASSWORD = new StringTestParameter("org.kie.server.pwd", "usetheforce123@");
-    private static final StringTestParameter KIE_SERVER_SERVICE_NAME = new StringTestParameter("org.kie.server.service.name", "myapp-execserv");
-
-    private static final StringTestParameter WORKBENCH_USER = new StringTestParameter("org.kie.workbench.user", "adminUser");
-    private static final StringTestParameter WORKBENCH_PASSWORD = new StringTestParameter("org.kie.workbench.pwd", "adminUser1!");
-    private static final StringTestParameter WORKBENCH_SERVICE_NAME = new StringTestParameter("org.kie.workbench.service.name", "myapp-buscentr");
+    public static final String KIE_APP_NAME = "kie.app.name";
 
     public static String getOpenShiftUrl() {
-        return OPENSHIFT_URL.getParameterValue();
+        return System.getProperty(OPENSHIFT_URL);
     }
 
     public static String getOpenShiftUserName() {
-        return OPENSHIFT_USER.getParameterValue();
+        return System.getProperty(OPENSHIFT_USER);
     }
 
     public static String getOpenShiftPassword() {
-        return OPENSHIFT_PASSWORD.getParameterValue();
+        return System.getProperty(OPENSHIFT_PASSWORD);
     }
 
     public static String getKieAppSecret() {
-        return KIE_APP_SECRET.getParameterValue();
+        return System.getProperty(KIE_APP_SECRET);
     }
 
     public static String getKieImageStreams() {
-        return KIE_IMAGE_STREAMS.getParameterValue();
+        return System.getProperty(KIE_IMAGE_STREAMS);
     }
 
     public static String getKieAppTemplate() {
-        return KIE_APP_TEMPLATE.getParameterValue();
+        return System.getProperty(KIE_APP_TEMPLATE);
     }
 
-    public static String getKieServerUser() {
-        return KIE_SERVER_USER.getParameterValue();
-    }
-
-    public static String getKieServerPassword() {
-        return KIE_SERVER_PASSWORD.getParameterValue();
-    }
-
-    public static String getKieServerServiceName() {
-        return KIE_SERVER_SERVICE_NAME.getParameterValue();
-    }
-
-    public static String getWorkbenchUser() {
-        return WORKBENCH_USER.getParameterValue();
-    }
-
-    public static String getWorkbenchPassword() {
-        return WORKBENCH_PASSWORD.getParameterValue();
-    }
-
-    public static String getWorkbenchServiceName() {
-        return WORKBENCH_SERVICE_NAME.getParameterValue();
-    }
-
-    // Used for printing all configuration values at the beginning of first test run.
-    static {
-        TreeMap<String, String> params = new TreeMap<String, String>();
-        int maxKeyLength = 0;
-        for (Field f : OpenShiftConstants.class.getDeclaredFields()) {
-            if (StringTestParameter.class.isAssignableFrom(f.getType())) {
-                try {
-                    String paramName = f.getName();
-                    StringTestParameter paramValue = (StringTestParameter) f.get(null);
-                    maxKeyLength = Math.max(maxKeyLength, paramName.length());
-                    params.put(paramName, paramValue.getParameterValue().toString());
-                } catch (IllegalAccessException ex) {
-                    LOGGER.error("Cannot read field '{}'.", f.getName(), ex);
-                }
-            }
-        }
-        for (Map.Entry<String, String> entry : params.entrySet()) {
-            String paramName = entry.getKey();
-            String value = entry.getValue();
-
-            LOGGER.info("{} = {}",
-                    String.format("%" + maxKeyLength + "s", paramName),
-                    value
-            );
-        }
-    }
-
-    private static class StringTestParameter {
-
-        private String key;
-        private String defaultValue;
-
-        private StringTestParameter(String key) {
-            this.key = key;
-        }
-
-        private StringTestParameter(String key, String defaultValue) {
-            this.key = key;
-            this.defaultValue = defaultValue;
-        }
-
-        /**
-         * @return Parameter value.
-         */
-        public String getParameterValue() {
-            String parameterValue = convert(key);
-            return parameterValue != null ? parameterValue : defaultValue;
-        }
-
-        private String convert(String key) {
-            String systemPropertyValue = System.getProperty(key);
-            if (systemPropertyValue == null || systemPropertyValue.isEmpty()) {
-                return null;
-            }
-            return systemPropertyValue;
-        }
+    public static String getKieApplicationName() {
+        return System.getProperty(KIE_APP_NAME);
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/KieServerDeploymentImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/KieServerDeploymentImpl.java
@@ -74,8 +74,8 @@ public class KieServerDeploymentImpl implements KieServerDeployment {
         return serviceName;
     }
 
-    public void setServiceName(String serviceName) {
-        this.serviceName = serviceName;
+    public void setServiceName(String applicationName) {
+        this.serviceName = applicationName + "-execserv";
     }
 
     @Override public void scale(int instances) {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/WorkbenchDeploymentImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/WorkbenchDeploymentImpl.java
@@ -74,8 +74,8 @@ public class WorkbenchDeploymentImpl implements WorkbenchDeployment {
         return serviceName;
     }
 
-    public void setServiceName(String serviceName) {
-        this.serviceName = serviceName;
+    public void setServiceName(String applicationName) {
+        this.serviceName = applicationName + "-buscentr";
     }
 
     @Override public void scale(int instances) {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/OpenShiftResourceConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/OpenShiftResourceConstants.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.cloud.openshift.resource;
+
+public class OpenShiftResourceConstants {
+
+    // Service constants
+    public static final String EAP_DEFAULT_PROTOCOL = "TCP";
+    public static final int EAP_DEFAULT_HTTP_PORT = 8080;
+
+    // Deployment config constants
+    public static final String DEPLOYMENT_TRIGGER_CONFIG_CHANGE = "ConfigChange";
+    public static final long DEPLOYMENT_CONFIG_CREATION_TIMEOUT = 60 * 1000L; // 1 minute
+    public static final String DEPLOYMENT_CONFIG_LABEL = "deploymentConfig";
+
+    // Route constants
+    public static final String CENTRAL_CI_ROUTE_SUFFIX = ".project.openshiftdomain";
+    public static final String ROUTE_REDIRECT_COMPONENT_TYPE = "Service";
+    public static final int ROUTE_REDIRECT_DEFAULT_WEIGHT = 100;
+
+    // Pod constants
+    public static final long DEPLOYMENT_PODS_TERMINATION_TIMEOUT = 10 * 60 * 1000L; // 10 minutes
+    public static final long PODS_START_TO_READY_TIMEOUT = 10 * 60 * 1000L; // 10 minutes
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/DeploymentConfigImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/DeploymentConfigImpl.java
@@ -21,8 +21,8 @@ import java.util.concurrent.TimeUnit;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.client.OpenShiftClient;
-import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.resource.DeploymentConfig;
+import org.kie.cloud.openshift.resource.OpenShiftResourceConstants;
 
 public class DeploymentConfigImpl implements DeploymentConfig {
 
@@ -60,11 +60,11 @@ public class DeploymentConfigImpl implements DeploymentConfig {
     }
 
     private void waitUntilAllPodsAreStarted() {
-        long timeoutTime = Calendar.getInstance().getTimeInMillis() + OpenShiftConstants.DEPLOYMENT_PODS_TERMINATION_TIMEOUT;
+        long timeoutTime = Calendar.getInstance().getTimeInMillis() + OpenShiftResourceConstants.DEPLOYMENT_PODS_TERMINATION_TIMEOUT;
         int expectedPods = client.deploymentConfigs().inNamespace(projectName).withName(deploymentConfigName).get().getSpec().getReplicas().intValue();
 
         while(Calendar.getInstance().getTimeInMillis() < timeoutTime) {
-            if(client.pods().inNamespace(projectName).withLabel(OpenShiftConstants.DEPLOYMENT_CONFIG_LABEL, deploymentConfigName).list().getItems().size() == expectedPods) {
+            if(client.pods().inNamespace(projectName).withLabel(OpenShiftResourceConstants.DEPLOYMENT_CONFIG_LABEL, deploymentConfigName).list().getItems().size() == expectedPods) {
                 return;
             }
 
@@ -79,10 +79,10 @@ public class DeploymentConfigImpl implements DeploymentConfig {
     }
 
     private void waitUntilAllPodsAreRunning() {
-        List<Pod> pods = client.pods().inNamespace(projectName).withLabel(OpenShiftConstants.DEPLOYMENT_CONFIG_LABEL, deploymentConfigName).list().getItems();
+        List<Pod> pods = client.pods().inNamespace(projectName).withLabel(OpenShiftResourceConstants.DEPLOYMENT_CONFIG_LABEL, deploymentConfigName).list().getItems();
         for(Pod pod : pods) {
             try {
-                client.pods().inNamespace(projectName).withName(pod.getMetadata().getName()).waitUntilReady(OpenShiftConstants.PODS_START_TO_READY_TIMEOUT, TimeUnit.MILLISECONDS);
+                client.pods().inNamespace(projectName).withName(pod.getMetadata().getName()).waitUntilReady(OpenShiftResourceConstants.PODS_START_TO_READY_TIMEOUT, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException("Interrupted while waiting for pod to be ready.", e);

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
@@ -31,7 +31,7 @@ import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.openshift.client.OpenShiftClient;
-import org.kie.cloud.openshift.constants.OpenShiftConstants;
+import org.kie.cloud.openshift.resource.OpenShiftResourceConstants;
 import org.kie.cloud.openshift.resource.Project;
 import org.kie.cloud.openshift.resource.Service;
 
@@ -57,7 +57,7 @@ public class ProjectImpl implements Project {
 
     @Override
     public Service createService(String service) {
-        return createService(service, OpenShiftConstants.EAP_DEFAULT_PROTOCOL, OpenShiftConstants.EAP_DEFAULT_HTTP_PORT);
+        return createService(service, OpenShiftResourceConstants.EAP_DEFAULT_PROTOCOL, OpenShiftResourceConstants.EAP_DEFAULT_HTTP_PORT);
     }
 
     @Override

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ServiceImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ServiceImpl.java
@@ -28,7 +28,7 @@ import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import io.fabric8.openshift.api.model.DeploymentTriggerPolicyBuilder;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import org.kie.cloud.openshift.constants.OpenShiftConstants;
+import org.kie.cloud.openshift.resource.OpenShiftResourceConstants;
 import org.kie.cloud.openshift.resource.Service;
 
 public class ServiceImpl implements Service {
@@ -90,14 +90,14 @@ public class ServiceImpl implements Service {
                     .endTemplate()
                     .withTriggers(
                             new DeploymentTriggerPolicyBuilder()
-                            .withType(OpenShiftConstants.DEPLOYMENT_TRIGGER_CONFIG_CHANGE)
+                            .withType(OpenShiftResourceConstants.DEPLOYMENT_TRIGGER_CONFIG_CHANGE)
                             .build())
                     .withSelector(selector)
                 .endSpec()
                 .build());
 
         try {
-            client.deploymentConfigs().inNamespace(projectName).withName(serviceName).waitUntilReady(OpenShiftConstants.DEPLOYMENT_CONFIG_CREATION_TIMEOUT, TimeUnit.MILLISECONDS);
+            client.deploymentConfigs().inNamespace(projectName).withName(serviceName).waitUntilReady(OpenShiftResourceConstants.DEPLOYMENT_CONFIG_CREATION_TIMEOUT, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted while waiting for deployment to become ready.", e);
@@ -126,7 +126,7 @@ public class ServiceImpl implements Service {
 
     @Override
     public RouteImpl createRoute() {
-        String route = serviceName + OpenShiftConstants.CENTRAL_CI_ROUTE_SUFFIX;
+        String route = serviceName + OpenShiftResourceConstants.CENTRAL_CI_ROUTE_SUFFIX;
         return createRoute(route);
     }
 
@@ -140,9 +140,9 @@ public class ServiceImpl implements Service {
                 .endMetadata()
                 .withNewSpec()
                     .withNewTo()
-                        .withKind(OpenShiftConstants.ROUTE_REDIRECT_COMPONENT_TYPE)
+                        .withKind(OpenShiftResourceConstants.ROUTE_REDIRECT_COMPONENT_TYPE)
                         .withName(serviceName)
-                        .withWeight(OpenShiftConstants.ROUTE_REDIRECT_DEFAULT_WEIGHT)
+                        .withWeight(OpenShiftResourceConstants.ROUTE_REDIRECT_DEFAULT_WEIGHT)
                     .endTo()
                     .withHost(route)
                 .endSpec()

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchWithKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchWithKieServerScenarioImpl.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
+import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchWithKieServerScenario;
 import org.kie.cloud.openshift.OpenShiftController;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -74,35 +75,35 @@ public class WorkbenchWithKieServerScenarioImpl implements WorkbenchWithKieServe
 
         waitUntilAllPodsAreReady(project);
 
-        String routeHostWorkbench = project.getService(OpenShiftConstants.getWorkbenchServiceName()).getRoute().getRouteHost();
-        String urlWorkbench = "http://" + routeHostWorkbench;
-
         workbenchDeployment = new WorkbenchDeploymentImpl();
         workbenchDeployment.setOpenShiftController(openshiftController);
         workbenchDeployment.setNamespace(projectName);
+        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
+        workbenchDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchDeployment.setServiceName(OpenShiftConstants.getKieApplicationName());
+
+        String routeHostWorkbench = project.getService(workbenchDeployment.getServiceName()).getRoute().getRouteHost();
+        String urlWorkbench = "http://" + routeHostWorkbench;
         try {
             workbenchDeployment.setUrl(new URL(urlWorkbench));
         } catch (MalformedURLException e) {
             throw new RuntimeException("Malformed URL for workbench", e);
         }
-        workbenchDeployment.setUsername(OpenShiftConstants.getWorkbenchUser());
-        workbenchDeployment.setPassword(OpenShiftConstants.getWorkbenchPassword());
-        workbenchDeployment.setServiceName(OpenShiftConstants.getWorkbenchServiceName());
-
-        String routeHostKieServer = project.getService(OpenShiftConstants.getKieServerServiceName()).getRoute().getRouteHost();
-        String urlKieServer = "http://" + routeHostKieServer;
 
         kieServerDeployment = new KieServerDeploymentImpl();
         kieServerDeployment.setOpenShiftController(openshiftController);
         kieServerDeployment.setNamespace(projectName);
+        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setServiceName(OpenShiftConstants.getKieApplicationName());
+
+        String routeHostKieServer = project.getService(kieServerDeployment.getServiceName()).getRoute().getRouteHost();
+        String urlKieServer = "http://" + routeHostKieServer;
         try {
             kieServerDeployment.setUrl(new URL(urlKieServer));
         } catch (MalformedURLException e) {
             throw new RuntimeException("Malformed URL for kie server", e);
         }
-        kieServerDeployment.setUsername(OpenShiftConstants.getKieServerUser());
-        kieServerDeployment.setPassword(OpenShiftConstants.getKieServerPassword());
-        kieServerDeployment.setServiceName(OpenShiftConstants.getKieServerServiceName());
     }
 
     @Override public void undeploy() {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchWithKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchWithKieServerScenarioBuilderImpl.java
@@ -18,10 +18,10 @@ package org.kie.cloud.openshift.scenario.builder;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchWithKieServerScenario;
 import org.kie.cloud.api.scenario.builder.WorkbenchWithKieServerScenarioBuilder;
 import org.kie.cloud.openshift.OpenShiftController;
-import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.scenario.WorkbenchWithKieServerScenarioImpl;
 
@@ -34,14 +34,14 @@ public class WorkbenchWithKieServerScenarioBuilderImpl implements WorkbenchWithK
         this.openshiftController = openShiftController;
 
         this.envVariables = new HashMap<String, String>();
-        this.envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, OpenShiftConstants.getKieServerUser());
-        this.envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, OpenShiftConstants.getKieServerPassword());
-        this.envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, OpenShiftConstants.getWorkbenchUser());
-        this.envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, OpenShiftConstants.getWorkbenchPassword());
+        this.envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
+        this.envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
+        this.envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
+        this.envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
 
         // By default use Workbench as maven repo, repo URL is derived from Workbench automatically if not defined
-        this.envVariables.put(OpenShiftTemplateConstants.MAVEN_REPO_USERNAME, OpenShiftConstants.getWorkbenchUser());
-        this.envVariables.put(OpenShiftTemplateConstants.MAVEN_REPO_PASSWORD, OpenShiftConstants.getWorkbenchPassword());
+        this.envVariables.put(OpenShiftTemplateConstants.MAVEN_REPO_USERNAME, DeploymentConstants.getWorkbenchUser());
+        this.envVariables.put(OpenShiftTemplateConstants.MAVEN_REPO_PASSWORD, DeploymentConstants.getWorkbenchPassword());
     }
 
     @Override

--- a/framework-cloud/framework-openshift/src/main/resources/META-INF/services/org.kie.cloud.api.constants.Constants
+++ b/framework-cloud/framework-openshift/src/main/resources/META-INF/services/org.kie.cloud.api.constants.Constants
@@ -1,0 +1,1 @@
+org.kie.cloud.openshift.constants.OpenShiftConstants

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -24,6 +24,7 @@
     <kie.image.streams/> <!-- Needs to be defined for proper test run. -->
     <kie.app.secret>https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/secrets/bpmsuite-app-secret.json</kie.app.secret>
     <kie.app.template>https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/bpmsuite/bpmsuite70-full-mysql.json</kie.app.template>
+    <kie.app.name>myapp</kie.app.name>
 
     <git.provider/> <!-- Currently supported GitLab and GitHub. Define one of them with related properties to run tests using GIT remote repository. -->
     <gitlab.url/>
@@ -31,6 +32,11 @@
     <gitlab.password/>
     <github.username/>
     <github.password/>
+
+    <org.kie.server.user>yoda</org.kie.server.user>
+    <org.kie.server.pwd>usetheforce123@</org.kie.server.pwd>
+    <org.kie.workbench.user>adminUser</org.kie.workbench.user>
+    <org.kie.workbench.pwd>adminUser1!</org.kie.workbench.pwd>
   </properties>
 
   <modules>
@@ -51,12 +57,17 @@
               <kie.app.secret>${kie.app.secret}</kie.app.secret>
               <kie.image.streams>${kie.image.streams}</kie.image.streams>
               <kie.app.template>${kie.app.template}</kie.app.template>
+              <kie.app.name>${kie.app.name}</kie.app.name>
               <git.provider>${git.provider}</git.provider>
               <gitlab.url>${gitlab.url}</gitlab.url>
               <gitlab.username>${gitlab.username}</gitlab.username>
               <gitlab.password>${gitlab.password}</gitlab.password>
               <github.username>${github.username}</github.username>
               <github.password>${github.password}</github.password>
+              <org.kie.server.user>${org.kie.server.user}</org.kie.server.user>
+              <org.kie.server.pwd>${org.kie.server.pwd}</org.kie.server.pwd>
+              <org.kie.workbench.user>${org.kie.workbench.user}</org.kie.workbench.user>
+              <org.kie.workbench.pwd>${org.kie.workbench.pwd}</org.kie.workbench.pwd>
             </systemProperties>
           </configuration>
         </plugin>


### PR DESCRIPTION
Changes:
- Separated test constant printing logic to TestInfoPrinter
- Split existing constants to OpenShiftConstants, GitConstants and DeploymentConstants
- Constants for printing are loaded by service loader, to print just ones we could use
- Adjusted service name configuration for deployment. It is now created directly in specific deployment based  on applicationName.
- Moved default values from constants to pom properties.

TestInfoPrinter is invoked in DeploymentConstants. I currently didn't find out any better place where to put it. It should be invoked once in the beginning of all tests.