### PR TITLE
Add workbench context root property for UI tests & cleanup

### DIFF
--- a/framework-cloud/cloud-deployment-plugin/src/main/java/org/kie/cloud/plugin/CloudDeploymentPluginConfiguration.java
+++ b/framework-cloud/cloud-deployment-plugin/src/main/java/org/kie/cloud/plugin/CloudDeploymentPluginConfiguration.java
@@ -20,9 +20,7 @@ import static org.kie.cloud.plugin.Constants.NAMESPACE_PROPERTY;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Properties;

--- a/framework-cloud/cloud-deployment-plugin/src/main/java/org/kie/cloud/plugin/Constants.java
+++ b/framework-cloud/cloud-deployment-plugin/src/main/java/org/kie/cloud/plugin/Constants.java
@@ -16,13 +16,16 @@
 package org.kie.cloud.plugin;
 
 public class Constants {
-    public static final String PROPERTY_FILE_PATH = "cloud-urls.properties";
-    public static final String CLOUD_API_IMPLEMENTATION_PROPERTY = "cloud.api.implementation";
-    public static final String NAMESPACE_PROPERTY = "namespace";
-    public static final String WORKBENCH_URL_PROPERTY = "url";
-    public static final String WORKBENCH_USERNAME_PROPERTY = "bcentral.openshift.username";
-    public static final String WORKBENCH_PASSWORD_PROPERTY = "bcentral.openshift.password";
 
-    public static final String BUILD_PROPERTIES_BUSINESS_CENTRAL_IP = "as.ip";
-    public static final String BUILD_PROPERTIES_BUSINESS_CENTRAL_PORT = "as.port";
+    public static final String
+            PROPERTY_FILE_PATH = "cloud-urls.properties",
+            CLOUD_API_IMPLEMENTATION_PROPERTY = "cloud.api.implementation",
+            NAMESPACE_PROPERTY = "namespace",
+
+            // properties required by UI tests to be able to connect to workbench via browser
+            BUILD_PROPERTIES_WORKBENCH_IP = "as.ip",
+            BUILD_PROPERTIES_WORKBENCH_PORT = "as.port",
+            BUILD_PROPERTIES_WORKBENCH_CONTEXT_ROOT = "web.context-root",
+            BUILD_PROPERTIES_WORKBENCH_USERNAME = "workbench.openshift.username",
+            BUILD_PROPERTIES_WORKBENCH_PASSWORD = "workbench.openshift.password";
 }

--- a/framework-cloud/cloud-deployment-plugin/src/main/java/org/kie/cloud/plugin/Undeploy.java
+++ b/framework-cloud/cloud-deployment-plugin/src/main/java/org/kie/cloud/plugin/Undeploy.java
@@ -15,11 +15,9 @@
 
 package org.kie.cloud.plugin;
 
+import static org.kie.cloud.plugin.Constants.PROPERTY_FILE_PATH;
+
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -29,10 +27,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
-
-import static org.kie.cloud.plugin.Constants.CLOUD_API_IMPLEMENTATION_PROPERTY;
-import static org.kie.cloud.plugin.Constants.NAMESPACE_PROPERTY;
-import static org.kie.cloud.plugin.Constants.PROPERTY_FILE_PATH;
 
 @Mojo( name = "undeploy" )
 public class Undeploy extends AbstractMojo {

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/constants/TestInfoPrinter.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/constants/TestInfoPrinter.java
@@ -53,7 +53,7 @@ public class TestInfoPrinter {
             String value = entry.getValue();
 
             logger.info("{} = {}",
-                    String.format("%" + maxKeyLength + "s", paramName),
+                    String.format("%-" + maxKeyLength + "s", paramName),
                     value
             );
         }


### PR DESCRIPTION
This PR solves several problems:
1) UI tests require context url which they read from system property like
web.context-root=business-central

This is now necessary, because there's no context root (in this case the logic sets it to empty string) in workbench urls when deployed to workbench.

2) Also required by ui tests are explicit port numbers which I'm providing in case they're missing in the url

3) Also improved formatting of Test properties printout - now all property names are left-aligned to make them more readable. (using "-" in the format string).
```
[INFO] kie.app.name           = myapp
[INFO] kie.app.secret         = [SOMEURL]
[INFO] kie.app.template       = [SOMEURL]
[INFO] kie.image.streams      = [SOMEURL]
[INFO] openshift.master.url   = [SOMEURL]
[INFO] openshift.password     = redhat
[INFO] openshift.username     = user
[INFO] org.kie.server.pwd     = usetheforce123@
[INFO] org.kie.server.user    = yoda
[INFO] org.kie.workbench.pwd  = adminUser1!
[INFO] org.kie.workbench.user = adminUser
```

Other than that just removing unused imports and unused `WORKBENCH_URL_PROPERTY`