### PR TITLE
Openshift external database

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/DeploymentScenarioBuilderFactory.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/DeploymentScenarioBuilderFactory.java
@@ -15,6 +15,8 @@
 
 package org.kie.cloud.api;
 
+import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
+import org.kie.cloud.api.scenario.builder.KieServerWithExternalDatabaseScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.WorkbenchRuntimeSmartRouterKieServerDatabaseScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.WorkbenchWithKieServerScenarioBuilder;
 
@@ -23,6 +25,7 @@ public interface DeploymentScenarioBuilderFactory {
 
     WorkbenchWithKieServerScenarioBuilder getWorkbenchWithKieServerScenarioBuilder();
     WorkbenchRuntimeSmartRouterKieServerDatabaseScenarioBuilder getWorkbenchRuntimeSmartRouterKieServerDatabaseScenarioBuilder();
+    KieServerWithExternalDatabaseScenarioBuilder getKieServerWithExternalDatabaseScenarioBuilder();
 
     void deleteNamespace(String namespace);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
@@ -30,7 +30,10 @@ public class DeploymentConstants implements Constants {
     public static final String WORKBENCH_USER = "org.kie.workbench.user";
     public static final String WORKBENCH_PASSWORD = "org.kie.workbench.pwd";
 
+    public static final String DATABASE_HOST = "db.hostname";
     public static final String DATABASE_NAME = "database.name";
+    public static final String DATABASE_USERNAME = "db.username";
+    public static final String DATABASE_PASSWORD = "db.password";
 
     public static String getKieServerUser() {
         return System.getProperty(KIE_SERVER_USER);
@@ -48,7 +51,19 @@ public class DeploymentConstants implements Constants {
         return System.getProperty(WORKBENCH_PASSWORD);
     }
 
+    public static String getDatabaseHost() {
+        return System.getProperty(DATABASE_HOST);
+    }
+
     public static String getDatabaseName() {
         return System.getProperty(DATABASE_NAME);
+    }
+
+    public static String getDatabaseUsername() {
+        return System.getProperty(DATABASE_USERNAME);
+    }
+
+    public static String getDatabasePassword() {
+        return System.getProperty(DATABASE_PASSWORD);
     }
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
@@ -32,6 +32,7 @@ public class DeploymentConstants implements Constants {
 
     public static final String DATABASE_HOST = "db.hostname";
     public static final String DATABASE_NAME = "database.name";
+    public static final String EXTERNAL_DATABASE_NAME = "db.name";
     public static final String DATABASE_USERNAME = "db.username";
     public static final String DATABASE_PASSWORD = "db.password";
 
@@ -57,6 +58,10 @@ public class DeploymentConstants implements Constants {
 
     public static String getDatabaseName() {
         return System.getProperty(DATABASE_NAME);
+    }
+
+    public static String getExternalDatabaseName() {
+        return System.getProperty(EXTERNAL_DATABASE_NAME);
     }
 
     public static String getDatabaseUsername() {

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieServerWithExternalDatabaseScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieServerWithExternalDatabaseScenario.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.cloud.api.scenario;
 
 import org.kie.cloud.api.deployment.KieServerDeployment;

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieServerWithExternalDatabaseScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieServerWithExternalDatabaseScenario.java
@@ -1,0 +1,17 @@
+package org.kie.cloud.api.scenario;
+
+import org.kie.cloud.api.deployment.KieServerDeployment;
+
+/**
+ * Representation of deployment scenario with Kie server and external database.
+ */
+public interface KieServerWithExternalDatabaseScenario extends DeploymentScenario {
+
+    /**
+     * Return Kie Server deployment.
+     *
+     * @return KieServerDeployment
+     * @see KieServerDeployment
+     */
+    KieServerDeployment getKieServerDeployment();
+}

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/KieServerWithExternalDatabaseScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/KieServerWithExternalDatabaseScenarioBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.cloud.api.scenario.builder;
 
 import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/KieServerWithExternalDatabaseScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/KieServerWithExternalDatabaseScenarioBuilder.java
@@ -1,0 +1,7 @@
+package org.kie.cloud.api.scenario.builder;
+
+import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
+
+public interface KieServerWithExternalDatabaseScenarioBuilder extends DeploymentScenarioBuilder<KieServerWithExternalDatabaseScenario> {
+    public KieServerWithExternalDatabaseScenarioBuilder withExternalMavenRepo(String repoUrl, String repoUserName, String repoPassword);
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/DeploymentBuilderFactory.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/DeploymentBuilderFactory.java
@@ -16,10 +16,12 @@
 package org.kie.cloud.openshift;
 
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
+import org.kie.cloud.api.scenario.builder.KieServerWithExternalDatabaseScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.WorkbenchRuntimeSmartRouterKieServerDatabaseScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.WorkbenchWithKieServerScenarioBuilder;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.resource.Project;
+import org.kie.cloud.openshift.scenario.builder.KieServerWithExternalDatabaseScenarioBuilderImpl;
 import org.kie.cloud.openshift.scenario.builder.WorkbenchRuntimeSmartRouterKieServerDatabaseScenarioBuilderImpl;
 import org.kie.cloud.openshift.scenario.builder.WorkbenchWithKieServerScenarioBuilderImpl;
 
@@ -47,6 +49,10 @@ public class DeploymentBuilderFactory implements DeploymentScenarioBuilderFactor
     @Override
     public WorkbenchRuntimeSmartRouterKieServerDatabaseScenarioBuilder getWorkbenchRuntimeSmartRouterKieServerDatabaseScenarioBuilder() {
         return new WorkbenchRuntimeSmartRouterKieServerDatabaseScenarioBuilderImpl(controller);
+    }
+
+    @Override public KieServerWithExternalDatabaseScenarioBuilder getKieServerWithExternalDatabaseScenarioBuilder() {
+        return new KieServerWithExternalDatabaseScenarioBuilderImpl(controller);
     }
 
     @Override

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
@@ -47,6 +47,10 @@ public class OpenShiftConstants implements Constants {
      */
     public static final String KIE_APP_TEMPLATE_WORKBENCH_KIE_SERVER_DATABASE = "kie.app.template.workbench.kie-server.database";
     /**
+     * URL pointing to OpenShift template file containing Kie server and external database.
+     */
+    public static final String KIE_APP_TEMPLATE_KIE_SERVER_DATABASE_EXTERNAL = "kie.app.template.kie-server.database.external";
+    /**
      * URL pointing to OpenShift template file containing just Kie server.
      */
     public static final String KIE_APP_TEMPLATE_KIE_SERVER = "kie.app.template.kie-server";
@@ -93,6 +97,9 @@ public class OpenShiftConstants implements Constants {
 
     public static String getKieAppTemplateKieServerDatabase() {
         return System.getProperty(KIE_APP_TEMPLATE_KIE_SERVER_DATABASE);
+    }
+    public static String getKieAppTemplateKieServerDatabaseExternal() {
+        return System.getProperty(KIE_APP_TEMPLATE_KIE_SERVER_DATABASE_EXTERNAL);
     }
 
     public static String getKieAppTemplateConsoleSmartRouter() {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftTemplateConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftTemplateConstants.java
@@ -40,6 +40,11 @@ public class OpenShiftTemplateConstants {
     public static final String IMAGE_STREAM_NAMESPACE = "IMAGE_STREAM_NAMESPACE";
     public static final String APPLICATION_NAME = "APPLICATION_NAME";
 
+    public static final String DB_HOST = "DB_HOST";
+    public static final String DB_DATABASE = "DB_DATABASE";
+    public static final String DB_USERNAME = "DB_USERNAME";
+    public static final String DB_PASSWORD = "DB_PASSWORD";
+
     public static final String BUSINESS_CENTRAL_HOSTNAME_HTTP = "BUSINESS_CENTRAL_HOSTNAME_HTTP";
     public static final String BUSINESS_CENTRAL_HOSTNAME_HTTPS = "BUSINESS_CENTRAL_HOSTNAME_HTTPS";
     public static final String EXECUTION_SERVER_HOSTNAME_HTTP = "EXECUTION_SERVER_HOSTNAME_HTTP";

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioImpl.java
@@ -1,0 +1,83 @@
+package org.kie.cloud.openshift.scenario;
+
+import static org.kie.cloud.openshift.scenario.util.ProjectUtils.createProject;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.kie.cloud.api.deployment.Deployment;
+import org.kie.cloud.api.deployment.KieServerDeployment;
+import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
+import org.kie.cloud.common.logs.InstanceLogUtil;
+import org.kie.cloud.openshift.OpenShiftController;
+import org.kie.cloud.openshift.constants.OpenShiftConstants;
+import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
+import org.kie.cloud.openshift.deployment.KieServerDeploymentImpl;
+import org.kie.cloud.openshift.resource.Project;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KieServerWithExternalDatabaseScenarioImpl implements KieServerWithExternalDatabaseScenario {
+
+    private OpenShiftController openshiftController;
+    private KieServerDeploymentImpl kieServerDeployment;
+    private Project project;
+    private Map<String, String> envVariables;
+
+    private static final Logger logger = LoggerFactory.getLogger(KieServerWithExternalDatabaseScenario.class);
+
+    public KieServerWithExternalDatabaseScenarioImpl(OpenShiftController openShiftController, Map<String, String> envVariables) {
+        this.openshiftController = openShiftController;
+        this.envVariables = envVariables;
+    }
+
+    @Override public KieServerDeployment getKieServerDeployment() {
+        return kieServerDeployment;
+    }
+
+    @Override public String getNamespace() {
+        return project.getName();
+    }
+
+    @Override public void deploy() {
+        project = createProject(openshiftController);
+
+        logger.info("Processing template and creating resources from " + OpenShiftConstants.getKieAppTemplateWorkbenchKieServerDatabase());
+        envVariables.put(OpenShiftTemplateConstants.IMAGE_STREAM_NAMESPACE, project.getName());
+        project.processTemplateAndCreateResources(OpenShiftConstants.getKieAppTemplateKieServerDatabaseExternal(), envVariables);
+
+        kieServerDeployment = new KieServerDeploymentImpl();
+        kieServerDeployment.setOpenShiftController(openshiftController);
+        kieServerDeployment.setNamespace(project.getName());
+        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setServiceName(OpenShiftConstants.getKieApplicationName());
+        kieServerDeployment.setSecureServiceName(OpenShiftConstants.getKieApplicationName());
+
+        logger.info("Waiting for Kie server deployment to become ready.");
+        kieServerDeployment.waitForScale();
+    }
+
+    @Override public void undeploy() {
+        InstanceLogUtil.writeDeploymentLogs(this);
+
+        for(Deployment deployment : getDeployments()) {
+            if(deployment != null) {
+                deployment.scale(0);
+                deployment.waitForScale();
+            }
+        }
+
+        project.delete();
+    }
+
+    public OpenShiftController getOpenshiftController() {
+        return openshiftController;
+    }
+
+    @Override public List<Deployment> getDeployments() {
+        return Arrays.asList(kieServerDeployment);
+    }
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.cloud.openshift.scenario;
 
 import static org.kie.cloud.openshift.scenario.util.ProjectUtils.createProject;

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderImpl.java
@@ -1,4 +1,25 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.cloud.openshift.scenario.builder;
+
+import static org.kie.cloud.api.deployment.constants.DeploymentConstants.getDatabaseHost;
+import static org.kie.cloud.api.deployment.constants.DeploymentConstants.getDatabaseName;
+import static org.kie.cloud.api.deployment.constants.DeploymentConstants.getDatabasePassword;
+import static org.kie.cloud.api.deployment.constants.DeploymentConstants.getDatabaseUsername;
+import static org.kie.cloud.api.deployment.constants.DeploymentConstants.getExternalDatabaseName;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,10 +44,10 @@ public class KieServerWithExternalDatabaseScenarioBuilderImpl implements KieServ
         this.envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
         this.envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
 
-        this.envVariables.put("DB_HOST", System.getProperty("db.hostname"));
-        this.envVariables.put("DB_DATABASE", System.getProperty("db.name"));
-        this.envVariables.put("DB_USERNAME", System.getProperty("db.username"));
-        this.envVariables.put("DB_PASSWORD", System.getProperty("db.password"));
+        this.envVariables.put(OpenShiftTemplateConstants.DB_HOST, getDatabaseHost());
+        this.envVariables.put(OpenShiftTemplateConstants.DB_DATABASE, getExternalDatabaseName());
+        this.envVariables.put(OpenShiftTemplateConstants.DB_USERNAME, getDatabaseUsername());
+        this.envVariables.put(OpenShiftTemplateConstants.DB_PASSWORD, getDatabasePassword());
     }
 
     @Override public KieServerWithExternalDatabaseScenario build() {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderImpl.java
@@ -1,0 +1,43 @@
+package org.kie.cloud.openshift.scenario.builder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
+import org.kie.cloud.api.scenario.builder.KieServerWithExternalDatabaseScenarioBuilder;
+import org.kie.cloud.api.scenario.builder.WorkbenchWithKieServerScenarioBuilder;
+import org.kie.cloud.openshift.OpenShiftController;
+import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
+import org.kie.cloud.openshift.scenario.KieServerWithExternalDatabaseScenarioImpl;
+
+public class KieServerWithExternalDatabaseScenarioBuilderImpl implements KieServerWithExternalDatabaseScenarioBuilder {
+
+    private OpenShiftController openshiftController;
+    private Map<String, String> envVariables;
+
+    public KieServerWithExternalDatabaseScenarioBuilderImpl(OpenShiftController openShiftController) {
+        this.openshiftController = openShiftController;
+
+        this.envVariables = new HashMap<String, String>();
+        this.envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
+        this.envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
+
+        this.envVariables.put("DB_HOST", System.getProperty("db.hostname"));
+        this.envVariables.put("DB_DATABASE", System.getProperty("db.name"));
+        this.envVariables.put("DB_USERNAME", System.getProperty("db.username"));
+        this.envVariables.put("DB_PASSWORD", System.getProperty("db.password"));
+    }
+
+    @Override public KieServerWithExternalDatabaseScenario build() {
+        return new KieServerWithExternalDatabaseScenarioImpl(openshiftController, envVariables);
+    }
+
+    @Override
+    public KieServerWithExternalDatabaseScenarioBuilder withExternalMavenRepo(String repoUrl, String repoUserName, String repoPassword) {
+        this.envVariables.put(OpenShiftTemplateConstants.MAVEN_REPO_URL, repoUrl);
+        this.envVariables.put(OpenShiftTemplateConstants.MAVEN_REPO_USERNAME, repoUserName);
+        this.envVariables.put(OpenShiftTemplateConstants.MAVEN_REPO_PASSWORD, repoPassword);
+        return this;
+    }
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/util/ProjectUtils.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/util/ProjectUtils.java
@@ -1,0 +1,34 @@
+package org.kie.cloud.openshift.scenario.util;
+
+import java.util.UUID;
+
+import org.kie.cloud.openshift.OpenShiftController;
+import org.kie.cloud.openshift.constants.OpenShiftConstants;
+import org.kie.cloud.openshift.resource.Project;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProjectUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProjectUtils.class);
+
+    public static Project createProject(OpenShiftController openshiftController) {
+        String projectName = UUID.randomUUID().toString().substring(0, 4);
+        if (OpenShiftConstants.getNamespacePrefix().isPresent()) {
+            projectName = OpenShiftConstants.getNamespacePrefix().get() + "-" + projectName;
+        }
+
+        logger.info("Generated project name is " + projectName);
+
+        logger.info("Creating project " + projectName);
+        Project project = openshiftController.createProject(projectName);
+
+        logger.info("Creating secrets from " + OpenShiftConstants.getKieAppSecret());
+        project.createResources(OpenShiftConstants.getKieAppSecret());
+
+        logger.info("Creating image streams from " + OpenShiftConstants.getKieImageStreams());
+        project.createResources(OpenShiftConstants.getKieImageStreams());
+
+        return project;
+    }
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/util/ProjectUtils.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/util/ProjectUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.cloud.openshift.scenario.util;
 
 import java.util.UUID;

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -86,7 +86,12 @@
               <kie.app.template.workbench.kie-server.database>${kie.app.template.workbench.kie-server.database}</kie.app.template.workbench.kie-server.database>
               <kie.app.template.kie-server>${kie.app.template.kie-server}</kie.app.template.kie-server>
               <kie.app.template.kie-server.database>${kie.app.template.kie-server.database}</kie.app.template.kie-server.database>
+              <kie.app.template.kie-server.database.external>${kie.app.template.kie-server.database.external}</kie.app.template.kie-server.database.external>
               <kie.app.template.workbench-monitoring.smartrouter>${kie.app.template.workbench-monitoring.smartrouter}</kie.app.template.workbench-monitoring.smartrouter>
+              <db.hostname>${db.hostname}</db.hostname>
+              <db.name>${db.name}</db.name>
+              <db.username>${db.username}</db.username>
+              <db.password>${db.password}</db.password>
               <kie.app.name>${kie.app.name}</kie.app.name>
               <git.provider>${git.provider}</git.provider>
               <gitlab.url>${gitlab.url}</gitlab.url>
@@ -138,6 +143,29 @@
               <configuration>
                 <files>
                   <file>${kie.app.templates.postgresql}</file>
+                </files>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>custom-parameters</id>
+      <activation>
+        <property>
+          <name>custom.parameters.file</name>
+        </property>
+            </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>properties-maven-plugin</artifactId>
+              <configuration>
+                <files>
+                  <file>${custom.parameters.file}</file>
                 </files>
               </configuration>
             </plugin>

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractCloudIntegrationTest.java
@@ -70,8 +70,13 @@ public abstract class AbstractCloudIntegrationTest<T extends DeploymentScenario>
 
     @After
     public void cleanEnvironment() {
-        deploymentScenario.undeploy();
-        gitProvider.deleteGitRepository(deploymentScenario.getNamespace());
+        if (deploymentScenario != null) {
+            deploymentScenario.undeploy();
+        }
+
+        if (gitProvider == null) {
+            gitProvider.deleteGitRepository(deploymentScenario.getNamespace());
+        }
     }
 
     protected abstract T createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory);

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractCloudIntegrationTest.java
@@ -72,10 +72,10 @@ public abstract class AbstractCloudIntegrationTest<T extends DeploymentScenario>
     public void cleanEnvironment() {
         if (deploymentScenario != null) {
             deploymentScenario.undeploy();
-        }
 
-        if (gitProvider == null) {
-            gitProvider.deleteGitRepository(deploymentScenario.getNamespace());
+            if (gitProvider != null) {
+                gitProvider.deleteGitRepository(deploymentScenario.getNamespace());
+            }
         }
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/ExternalDatabaseIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/ExternalDatabaseIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.cloud.integrationtests.persistence;
 
 import static org.junit.Assume.assumeTrue;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/ExternalDatabaseIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/ExternalDatabaseIntegrationTest.java
@@ -1,0 +1,79 @@
+package org.kie.cloud.integrationtests.persistence;
+
+import static org.junit.Assume.assumeTrue;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
+import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
+import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.maven.MavenDeployer;
+import org.kie.cloud.maven.constants.MavenConstants;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.api.model.instance.TaskSummary;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.ProcessServicesClient;
+import org.kie.server.client.UserTaskServicesClient;
+
+public class ExternalDatabaseIntegrationTest extends AbstractCloudIntegrationTest<KieServerWithExternalDatabaseScenario> {
+
+    private KieServicesClient kieServerClient;
+
+    @Override protected KieServerWithExternalDatabaseScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
+        assumeTrue(isExternalDatabaseAllocated());
+        return deploymentScenarioFactory.getKieServerWithExternalDatabaseScenarioBuilder()
+                .withExternalMavenRepo(MavenConstants.getMavenRepoUrl(), MavenConstants.getMavenRepoUser(), MavenConstants.getMavenRepoPassword())
+                .build();
+    }
+
+    @Before
+    public void setUp() {
+        kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
+    }
+
+    @Test
+    public void testKieServerRunning() {
+        ServiceResponse<KieServerInfo> kieServerInfoServiceResponse = kieServerClient.getServerInfo();
+        List<String> capabilities = kieServerInfoServiceResponse.getResult().getCapabilities();
+        Assertions.assertThat(capabilities).isNotEmpty();
+    }
+
+    @Test
+    public void testProcess() {
+        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
+
+        KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
+        ProcessServicesClient processClient = KieServerClientProvider.getProcessClient(deploymentScenario.getKieServerDeployment());
+        UserTaskServicesClient taskClient = KieServerClientProvider.getTaskClient(deploymentScenario.getKieServerDeployment());
+
+        kieServerClient.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID,
+                new ReleaseId(PROJECT_GROUP_ID, DEFINITION_PROJECT_SNAPSHOT_NAME, DEFINITION_PROJECT_SNAPSHOT_VERSION)));
+
+        Long userTaskPid = processClient.startProcess(CONTAINER_ID, USERTASK_PROCESS_ID);
+        Assertions.assertThat(userTaskPid).isNotNull();
+
+        List<TaskSummary> tasks = taskClient.findTasks(USER_YODA, 0, 10);
+        Assertions.assertThat(tasks).isNotNull().hasSize(1);
+
+        taskClient.completeAutoProgress(CONTAINER_ID, tasks.get(0).getId(), USER_YODA, null);
+
+        ProcessInstance userTaskPi = processClient.getProcessInstance(CONTAINER_ID, userTaskPid);
+        Assertions.assertThat(userTaskPi).isNotNull();
+        Assertions.assertThat(userTaskPi.getState()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED);
+    }
+
+    private boolean isExternalDatabaseAllocated() {
+        if (DeploymentConstants.getDatabaseHost().isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Enables testing with external database which runs outside the Openshift. New parameters for database configuration were introduced:
db.hostname - Database server address
db.name - Database schema name
db.username - Database user
db.password - Password for database user