### PR TITLE
Stabilize EmptyManagedKieServerConnectionIntegrationTest

### DIFF
--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/emptymanagedkieserver/EmptyManagedKieServerConnectionIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/emptymanagedkieserver/EmptyManagedKieServerConnectionIntegrationTest.java
@@ -29,6 +29,7 @@ import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.SmartRouterAdminClientProvider;
 import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.integrationtests.util.WorkbenchUtils;
 import org.kie.cloud.maven.MavenDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 import org.kie.server.api.model.KieContainerResourceList;
@@ -87,6 +88,7 @@ public class EmptyManagedKieServerConnectionIntegrationTest extends AbstractClou
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
         kieControllerClient.saveContainerSpec(serverInfo.getServerId(), serverInfo.getName(), CONTAINER_ID, CONTAINER_ALIAS, PROJECT_GROUP_ID, DEFINITION_PROJECT_SNAPSHOT_NAME, DEFINITION_PROJECT_SNAPSHOT_VERSION, KieContainerStatus.STARTED);
         KieServerClientProvider.waitForContainerStart(deploymentScenario.getKieServerDeployment(), CONTAINER_ID);
+        WorkbenchUtils.waitForContainerRegistration(kieControllerClient, SMART_ROUTER_ID, CONTAINER_ID);
 
         verifyContainerIsDeployed(kieServerClient, CONTAINER_ID);
         verifyServerTemplateContainsContainer(kieServerId, CONTAINER_ID);


### PR DESCRIPTION
Wait until container is registered in Smart router's server template.
Revealed thanks to PR builder.