### PR TITLE
Redeploy scenario in case of deployment timeout

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/Deployment.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/Deployment.java
@@ -41,8 +41,9 @@ public interface Deployment {
      * Wait until Deployment is ready to use. This method waits until all
      * instances of deployment are initialized and ready and for router to
      * expose url.
+     * @throws DeploymentTimeoutException In case deployment isn't scaled in defined timeout.
      */
-    void waitForScale();
+    void waitForScale() throws DeploymentTimeoutException;
 
     /**
      * Return list of all already running instances of the deployment.

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/DeploymentTimeoutException.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/DeploymentTimeoutException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.cloud.api.deployment;
+
+/**
+ * Exception thrown when deployment isn't ready in specified time.
+ */
+public class DeploymentTimeoutException extends RuntimeException{
+
+    private static final long serialVersionUID = -5043948043270445050L;
+
+    public DeploymentTimeoutException(String message) {
+        super(message);
+    }
+
+    public DeploymentTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/DeploymentScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/DeploymentScenario.java
@@ -18,6 +18,7 @@ package org.kie.cloud.api.scenario;
 import java.util.List;
 
 import org.kie.cloud.api.deployment.Deployment;
+import org.kie.cloud.api.deployment.DeploymentTimeoutException;
 
 /**
  * Cloud deployment scenario representation.
@@ -35,8 +36,9 @@ public interface DeploymentScenario {
      * Create and deploy deployment scenario.
      *
      * @throws MissingResourceException If scenario is missing any required resource.
+     * @throws DeploymentTimeoutException In case scenario deployment isn't started in defined timeout.
      */
-    void deploy() throws MissingResourceException;
+    void deploy() throws MissingResourceException, DeploymentTimeoutException;
 
     /**
      * Undeploy and delete deployment scenario.

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/DeploymentConfig.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/DeploymentConfig.java
@@ -15,6 +15,8 @@
 
 package org.kie.cloud.openshift.resource;
 
+import org.kie.cloud.api.deployment.DeploymentTimeoutException;
+
 /**
  * Deployment config representation.
  */
@@ -41,8 +43,9 @@ public interface DeploymentConfig {
 
     /**
      * Wait until all pods are initialized and ready.
+     * @throws DeploymentTimeoutException In case pods didn't start in defined timeout.
      */
-    public void waitUntilAllPodsAreReady();
+    public void waitUntilAllPodsAreReady() throws DeploymentTimeoutException;
 
     /**
      * Delete deployment controller.


### PR DESCRIPTION
Workaround for cases when persistent volume isn't cleared correctly, causing the pods to fail on startup.