### PR TITLE
Test adjustments

### DIFF
--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/https/KieServerHttpsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/https/KieServerHttpsIntegrationTest.java
@@ -74,6 +74,7 @@ public class KieServerHttpsIntegrationTest extends AbstractCloudIntegrationTest<
                 Assertions.assertThat(kieServerInfo.getCapabilities()).contains(KieServerConstants.CAPABILITY_BRM);
             }
         } catch (Exception e) {
+            logger.error("Unable to connect to KIE server REST API", e);
             throw new RuntimeException("Unable to connect to KIE server REST API", e);
         }
     }
@@ -97,6 +98,7 @@ public class KieServerHttpsIntegrationTest extends AbstractCloudIntegrationTest<
                 Assertions.assertThat(containers).contains(CONTAINER_ID);
             }
         } catch (Exception e) {
+            logger.error("Unable to connect to KIE server REST API", e);
             throw new RuntimeException("Unable to connect to KIE server REST API", e);
         }
     }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/https/WorkbenchHttpsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/https/WorkbenchHttpsIntegrationTest.java
@@ -71,6 +71,7 @@ public class WorkbenchHttpsIntegrationTest extends AbstractCloudIntegrationTest<
                 assertThat(responseContent).contains(WORKBENCH_LOGIN_SCREEN_TEXT);
             }
         } catch (IOException e) {
+            logger.error("Error in downloading workbench login screen using secure connection", e);
             fail("Error in downloading workbench login screen using secure connection", e);
         }
     }
@@ -88,6 +89,7 @@ public class WorkbenchHttpsIntegrationTest extends AbstractCloudIntegrationTest<
                 assertThat(serverTemplateExists(SERVER_ID, httpClient)).isTrue();
             }
         } catch (IOException e) {
+            logger.error("Unable to connect to workbench REST API", e);
             throw new RuntimeException("Unable to connect to workbench REST API", e);
         }
     }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
@@ -115,7 +115,8 @@ public class ProcessFailoverIntegrationTest extends AbstractCloudIntegrationTest
     private void signalStartLongScript(Long pid) {
         new Thread(() -> {
             try {
-                processServicesClient.signalProcessInstance(CONTAINER_ID, pid, SIGNAL_NAME, null);
+                ProcessServicesClient processClient = KieServerClientProvider.getProcessClient(deploymentScenario.getKieServerDeployment());
+                processClient.signalProcessInstance(CONTAINER_ID, pid, SIGNAL_NAME, null);
             } catch (KieServicesHttpException e) {
                 // Expected
             }


### PR DESCRIPTION
ProcessFailoverIntegrationTest - Use separate client for requests which will time out. Such timeout cause server URL to be removed from client, causing instability of original client which was used in subsequent calls.
HTTPS loggers - HTTPS tests seems to be occasionally unstable. However JUnit (or Failsafe plugin) isn't able to show nested exceptions. Loggers can do it, will help in instability analysis.