### PR TITLE
Generic scneario builder: add Smart router

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/DeploymentScenarioBuilderFactory.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/DeploymentScenarioBuilderFactory.java
@@ -21,6 +21,7 @@ import org.kie.cloud.api.scenario.builder.WorkbenchRuntimeSmartRouterKieServerDa
 import org.kie.cloud.api.scenario.builder.WorkbenchWithKieServerScenarioBuilder;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.api.settings.builder.KieServerSettingsBuilder;
+import org.kie.cloud.api.settings.builder.SmartRouterSettingsBuilder;
 import org.kie.cloud.api.settings.builder.WorkbenchMonitoringSettingsBuilder;
 import org.kie.cloud.api.settings.builder.WorkbenchSettingsBuilder;
 
@@ -36,6 +37,7 @@ public interface DeploymentScenarioBuilderFactory {
     KieServerS2ISettingsBuilder getKieServerS2ISettingsBuilder();
     WorkbenchSettingsBuilder getWorkbenchSettingsBuilder();
     WorkbenchMonitoringSettingsBuilder getWorkbenchMonitoringSettingsBuilder();
+    SmartRouterSettingsBuilder getSmartRouterSettingsBuilder();
 
     void deleteNamespace(String namespace);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
@@ -42,6 +42,8 @@ public class DeploymentConstants implements Constants {
     public static final String DATABASE_USERNAME = "db.username";
     public static final String DATABASE_PASSWORD = "db.password";
 
+    public static final String DEFAULT_DOMAIN_SUFFIX = "default.domain.suffix";
+
     public static String getKieServerUser() {
         return System.getProperty(KIE_SERVER_USER);
     }
@@ -96,5 +98,9 @@ public class DeploymentConstants implements Constants {
 
     public static String getHibernatePersistenceDialect() {
         return System.getProperty(HIBERNATE_PERSISTENCE_DIALECT);
+    }
+
+    public static String getDefaultDomainSuffix() {
+        return System.getProperty(DEFAULT_DOMAIN_SUFFIX);
     }
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/GenericScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/GenericScenario.java
@@ -17,6 +17,7 @@ package org.kie.cloud.api.scenario;
 
 import java.util.List;
 import org.kie.cloud.api.deployment.KieServerDeployment;
+import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 
 public interface GenericScenario extends DeploymentScenario {
@@ -36,4 +37,12 @@ public interface GenericScenario extends DeploymentScenario {
      * @see KieServerDeployment
      */
     List<KieServerDeployment> getKieServerDeployments();
+
+    /**
+     * Return List of all Smart Router deployments.
+     *
+     * @return SmartRouterDeployment
+     * @see SmartRouterDeployment
+     */
+    List<SmartRouterDeployment> getSmartRouterDeployments();
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/GenericScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/GenericScenarioBuilder.java
@@ -29,6 +29,14 @@ public interface GenericScenarioBuilder extends DeploymentScenarioBuilder<Generi
     GenericScenarioBuilder withKieServer(DeploymentSettings kieServerSettings);
 
     /**
+     * Return scenario Builder with added Kie Server deployment into scenario.
+     *
+     * @param kieServersSettings deployment settinfs for Kie Server.
+     * @return Builder
+     */
+    GenericScenarioBuilder withKieServer(DeploymentSettings... kieServersSettings);
+
+    /**
      * Return scenario Builder with added Workbench deployment into scenario.
      *
      * @param workbenchSettings
@@ -41,8 +49,16 @@ public interface GenericScenarioBuilder extends DeploymentScenarioBuilder<Generi
      * scenario.
      *
      * @param workbenchSettings
-     * @return
+     * @return Builder
      */
     GenericScenarioBuilder withMonitoring(DeploymentSettings workbenchSettings);
+
+    /**
+     * Return scenario Builder with added Smart router deployment into scenario.
+     *
+     * @param smartRouterSettings
+     * @return Builder
+     */
+    GenericScenarioBuilder withSmartRouter(DeploymentSettings smartRouterSettings);
 
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/builder/KieServerS2ISettingsBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/builder/KieServerS2ISettingsBuilder.java
@@ -79,6 +79,23 @@ public interface KieServerS2ISettingsBuilder extends SettingsBuilder<DeploymentS
     KieServerS2ISettingsBuilder withControllerConnection(String url, String port);
 
     /**
+     * Return configured builder with connection to Smart Router.
+     *
+     * @param url URL to Smart Router.
+     * @param port port of Smart Router.
+     * @return Builder.
+     */
+    KieServerS2ISettingsBuilder withSmartRouterConnection(String url, String port);
+
+    /**
+     * Return configured builder with connection to Smart Router.
+     *
+     * @param serviceName Smart Router service name.
+     * @return Builder.
+     */
+    KieServerS2ISettingsBuilder withSmartRouterConnection(String serviceName);
+
+    /**
      * Return configured builder with external database connection. Values for
      * external database are add by system properties.
      *
@@ -140,4 +157,23 @@ public interface KieServerS2ISettingsBuilder extends SettingsBuilder<DeploymentS
      * @return Builder
      */
     KieServerS2ISettingsBuilder withKieServerSyncDeploy(boolean syncDeploy);
+
+    /**
+     * Return configured builder with set host route. Custom hostname for http
+     * service route.
+     *
+     * @param http
+     * @return
+     */
+    KieServerS2ISettingsBuilder withHostame(String http);
+
+    /**
+     * Return configured builder with set secured host route. Custom hostname
+     * for https service route.
+     *
+     * @param https
+     * @return
+     */
+    KieServerS2ISettingsBuilder withSecuredHostame(String https);
+
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/builder/KieServerSettingsBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/builder/KieServerSettingsBuilder.java
@@ -70,6 +70,23 @@ public interface KieServerSettingsBuilder extends SettingsBuilder<DeploymentSett
     KieServerSettingsBuilder withControllerConnection(String url, String port);
 
     /**
+     * Return configured builder with connection to Smart Router.
+     *
+     * @param url URL to Smart Router.
+     * @param port port of Smart Router.
+     * @return Builder.
+     */
+    KieServerSettingsBuilder withSmartRouterConnection(String url, String port);
+
+    /**
+     * Return configured builder with connection to Smart Router.
+     *
+     * @param serviceName Smart Router service name.
+     * @return Builder.
+     */
+    KieServerSettingsBuilder withSmartRouterConnection(String serviceName);
+
+    /**
      * Return configured builder with Kie Container deployment.
      *
      * @param kieContainerDeployment Kie Container deployment.
@@ -127,4 +144,22 @@ public interface KieServerSettingsBuilder extends SettingsBuilder<DeploymentSett
      * @return Builder
      */
     KieServerSettingsBuilder withDroolsServerFilterClasses(boolean droolsFilter);
+
+    /**
+     * Return configured builder with set host route. Custom hostname for http
+     * service route.
+     *
+     * @param http
+     * @return
+     */
+    KieServerSettingsBuilder withHostame(String http);
+
+    /**
+     * Return configured builder with set secured host route. Custom hostname
+     * for https service route.
+     *
+     * @param https
+     * @return
+     */
+    KieServerSettingsBuilder withSecuredHostame(String https);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/builder/SmartRouterSettingsBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/builder/SmartRouterSettingsBuilder.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.api.settings.builder;
+
+import org.kie.cloud.api.settings.DeploymentSettings;
+
+public interface SmartRouterSettingsBuilder extends SettingsBuilder<DeploymentSettings> {
+
+    /**
+     * Return configured builder with application name.
+     *
+     * @param name Application name.
+     * @return Builder
+     */
+    SmartRouterSettingsBuilder withApplicationName(String name);
+
+    /**
+     * Return configured builder with Controller user.
+     *
+     * @param username Controller username.
+     * @param password Controller password.
+     * @return Builder
+     */
+    SmartRouterSettingsBuilder withControllerUser(String username, String password);
+
+    /**
+     * Return configured builder with Smart router ID.
+     *
+     * @param id Smart router id.
+     * @return Builder.
+     */
+    SmartRouterSettingsBuilder withSmartRouterID(String id);
+
+    /**
+     * Return configured builder with Smart router name.
+     *
+     * @param name Smart router name.
+     * @return Builder.
+     */
+    SmartRouterSettingsBuilder withSmartRouterName(String name);
+
+    /**
+     * Return configured builder with connection for Smart router.
+     *
+     * @param host Smartrouter host URL.
+     * @param port Smartrouter port.
+     * @return Builder
+     */
+    SmartRouterSettingsBuilder withSmarRouterConfig(String host, String port);
+
+    /**
+     * Return configured builder with connection  to Controller.
+     *
+     * @param host Controller host URL
+     * @param port Controller port.
+     * @return Builder
+     */
+    SmartRouterSettingsBuilder withControllerConnection(String host, String port);
+
+    /**
+     * Return configured builder with connection  to Controller.
+     *
+     * @param serviceName Controller service name.
+     * @return Builder
+     */
+    SmartRouterSettingsBuilder withControllerConnection(String serviceName);
+
+    /**
+     * Return configured builder with set external URL. Public URL where the
+     * router can be found. (router property org.kie.server.router.url.external)
+     *
+     * @param url Smart router external URL
+     * @return Builder
+     */
+    SmartRouterSettingsBuilder withSmartRouterExternalUrl(String url);
+
+    /**
+     * Return configured builder with set host route. Custom hostname for http
+     * service route.
+     *
+     * @param http
+     * @return
+     */
+    SmartRouterSettingsBuilder withHostame(String http);
+
+}

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/builder/WorkbenchSettingsBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/builder/WorkbenchSettingsBuilder.java
@@ -60,4 +60,22 @@ public interface WorkbenchSettingsBuilder extends SettingsBuilder<DeploymentSett
      * @return
      */
     WorkbenchSettingsBuilder withKieServerUser(String username, String password);
+
+    /**
+     * Return configured builder with set host route. Custom hostname for http
+     * service route.
+     *
+     * @param http
+     * @return
+     */
+    WorkbenchSettingsBuilder withHostame(String http);
+
+    /**
+     * Return configured builder with set secured host route. Custom hostname
+     * for https service route.
+     *
+     * @param https
+     * @return
+     */
+    WorkbenchSettingsBuilder withSecuredHostame(String https);
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/DeploymentBuilderFactory.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/DeploymentBuilderFactory.java
@@ -22,6 +22,7 @@ import org.kie.cloud.api.scenario.builder.WorkbenchRuntimeSmartRouterKieServerDa
 import org.kie.cloud.api.scenario.builder.WorkbenchWithKieServerScenarioBuilder;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.api.settings.builder.KieServerSettingsBuilder;
+import org.kie.cloud.api.settings.builder.SmartRouterSettingsBuilder;
 import org.kie.cloud.api.settings.builder.WorkbenchMonitoringSettingsBuilder;
 import org.kie.cloud.api.settings.builder.WorkbenchSettingsBuilder;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -32,6 +33,7 @@ import org.kie.cloud.openshift.scenario.builder.WorkbenchRuntimeSmartRouterKieSe
 import org.kie.cloud.openshift.scenario.builder.WorkbenchWithKieServerScenarioBuilderImpl;
 import org.kie.cloud.openshift.settings.builder.KieServerS2ISettingsBuilderImpl;
 import org.kie.cloud.openshift.settings.builder.KieServerSettingsBuilderImpl;
+import org.kie.cloud.openshift.settings.builder.SmartRouterSettingsBuilderImpl;
 import org.kie.cloud.openshift.settings.builder.WorkbenchMonitoringSettingsBuilderImpl;
 import org.kie.cloud.openshift.settings.builder.WorkbenchSettingsBuilderImpl;
 
@@ -88,6 +90,11 @@ public class DeploymentBuilderFactory implements DeploymentScenarioBuilderFactor
     @Override
     public WorkbenchMonitoringSettingsBuilder getWorkbenchMonitoringSettingsBuilder() {
         return new WorkbenchMonitoringSettingsBuilderImpl();
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder getSmartRouterSettingsBuilder() {
+        return new SmartRouterSettingsBuilderImpl();
     }
 
     @Override

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
@@ -75,6 +75,10 @@ public class OpenShiftConstants implements Constants {
      */
     public static final String KIE_APP_TEMPLATE_CONSOLE = "kie.app.template.workbench-monitoring";
     /**
+     * URL pointing to OpenShift template file containing Smart router.
+     */
+    public static final String KIE_APP_TEMPLATE_SMARTROUTER = "kie.app.template.smartrouter";
+    /**
      * URL pointing to OpenShift template file containing Workbench.
      */
     public static final String KIE_APP_TEMPLATE_WORKBENCH = "kie.app.template.workbench";

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftTemplateConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftTemplateConstants.java
@@ -37,9 +37,11 @@ public class OpenShiftTemplateConstants {
     public static final String KIE_SERVER_CONTROLLER_SERVICE = "KIE_SERVER_CONTROLLER_SERVICE";
 
     public static final String KIE_SERVER_ROUTER_ID = "KIE_SERVER_ROUTER_ID";
+    public static final String KIE_SERVER_ROUTER_NAME = "KIE_SERVER_ROUTER_NAME";
     public static final String KIE_SERVER_ROUTER_HOST = "KIE_SERVER_ROUTER_HOST";
     public static final String KIE_SERVER_ROUTER_PORT = "KIE_SERVER_ROUTER_PORT";
     public static final String KIE_SERVER_ROUTER_SERVICE = "KIE_SERVER_ROUTER_SERVICE";
+    public static final String KIE_SERVER_ROUTER_URL_EXTERNAL = "KIE_SERVER_ROUTER_URL_EXTERNAL";
 
     public static final String KIE_SERVER_BYPASS_AUTH_USER = "KIE_SERVER_BYPASS_AUTH_USER";
 
@@ -63,6 +65,7 @@ public class OpenShiftTemplateConstants {
     public static final String BUSINESS_CENTRAL_HOSTNAME_HTTPS = "BUSINESS_CENTRAL_HOSTNAME_HTTPS";
     public static final String EXECUTION_SERVER_HOSTNAME_HTTP = "EXECUTION_SERVER_HOSTNAME_HTTP";
     public static final String EXECUTION_SERVER_HOSTNAME_HTTPS = "EXECUTION_SERVER_HOSTNAME_HTTPS";
+    public static final String SMART_ROUTER_HOSTNAME_HTTP = "SMART_ROUTER_HOSTNAME_HTTP";
 
     public static final String KIE_SERVER_CONTAINER_DEPLOYMENT = "KIE_SERVER_CONTAINER_DEPLOYMENT";
 

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/builder/GenericScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/builder/GenericScenarioBuilderImpl.java
@@ -16,6 +16,7 @@
 package org.kie.cloud.openshift.scenario.builder;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.kie.cloud.api.scenario.GenericScenario;
@@ -31,22 +32,30 @@ public class GenericScenarioBuilderImpl implements GenericScenarioBuilder {
     private List<DeploymentSettings> kieServerSettingsList;
     private List<DeploymentSettings> workbenchSettingsList;
     private List<DeploymentSettings> monitoringSettingsList;
+    private List<DeploymentSettings> smartRouterSettingsList;
 
     public GenericScenarioBuilderImpl(OpenShiftController openShiftController) {
         this.openshiftController = openShiftController;
         this.kieServerSettingsList = new ArrayList<>();
         this.workbenchSettingsList = new ArrayList<>();
         this.monitoringSettingsList = new ArrayList<>();
+        this.smartRouterSettingsList = new ArrayList<>();
     }
 
     @Override
     public GenericScenario build() {
-        return new GenericScenarioImpl(openshiftController, kieServerSettingsList, workbenchSettingsList, monitoringSettingsList);
+        return new GenericScenarioImpl(openshiftController, kieServerSettingsList, workbenchSettingsList, monitoringSettingsList, smartRouterSettingsList);
     }
 
     @Override
     public GenericScenarioBuilder withKieServer(DeploymentSettings kieServerSettings) {
         kieServerSettingsList.add(kieServerSettings);
+        return this;
+    }
+
+    @Override
+    public GenericScenarioBuilder withKieServer(DeploymentSettings... kieServersSettings) {
+        kieServerSettingsList.addAll(Arrays.asList(kieServersSettings));
         return this;
     }
 
@@ -59,6 +68,12 @@ public class GenericScenarioBuilderImpl implements GenericScenarioBuilder {
     @Override
     public GenericScenarioBuilder withMonitoring(DeploymentSettings workbenchSettings) {
         monitoringSettingsList.add(workbenchSettings);
+        return this;
+    }
+
+    @Override
+    public GenericScenarioBuilder withSmartRouter(DeploymentSettings smartRouterSettings) {
+        smartRouterSettingsList.add(smartRouterSettings);
         return this;
     }
 

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/settings/builder/KieServerS2ISettingsBuilderImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/settings/builder/KieServerS2ISettingsBuilderImpl.java
@@ -83,6 +83,19 @@ public class KieServerS2ISettingsBuilderImpl implements KieServerS2ISettingsBuil
     }
 
     @Override
+    public KieServerS2ISettingsBuilder withSmartRouterConnection(String url, String port) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_HOST, url);
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_PORT, port);
+        return this;
+    }
+
+    @Override
+    public KieServerS2ISettingsBuilder withSmartRouterConnection(String serviceName) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_SERVICE, serviceName);
+        return this;
+    }
+
+    @Override
     public KieServerS2ISettingsBuilder withExternalDatabase() {
         envVariables.put(OpenShiftTemplateConstants.DBE_SERVICE_HOST, DeploymentConstants.getDatabaseHost());
         envVariables.put(OpenShiftTemplateConstants.DBE_DATABASE, DeploymentConstants.getExternalDatabaseName());
@@ -130,4 +143,17 @@ public class KieServerS2ISettingsBuilderImpl implements KieServerS2ISettingsBuil
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_SYNC_DEPLOY, Boolean.toString(syncDeploy));
         return this;
     }
+
+    @Override
+    public KieServerS2ISettingsBuilder withHostame(String http) {
+        envVariables.put(OpenShiftTemplateConstants.EXECUTION_SERVER_HOSTNAME_HTTP, http);
+        return this;
+    }
+
+    @Override
+    public KieServerS2ISettingsBuilder withSecuredHostame(String https) {
+        envVariables.put(OpenShiftTemplateConstants.EXECUTION_SERVER_HOSTNAME_HTTPS, https);
+        return this;
+    }
+
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/settings/builder/KieServerSettingsBuilderImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/settings/builder/KieServerSettingsBuilderImpl.java
@@ -76,6 +76,19 @@ public class KieServerSettingsBuilderImpl implements KieServerSettingsBuilder {
     }
 
     @Override
+    public KieServerSettingsBuilder withSmartRouterConnection(String url, String port) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_HOST, url);
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_PORT, port);
+        return this;
+    }
+
+    @Override
+    public KieServerSettingsBuilder withSmartRouterConnection(String serviceName) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_SERVICE, serviceName);
+        return this;
+    }
+
+    @Override
     public KieServerSettingsBuilder withContainerDeployment(String kieContainerDeployment) {
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTAINER_DEPLOYMENT, kieContainerDeployment);
         return this;
@@ -116,6 +129,18 @@ public class KieServerSettingsBuilderImpl implements KieServerSettingsBuilder {
     @Override
     public KieServerSettingsBuilder withDroolsServerFilterClasses(boolean droolsFilter) {
         envVariables.put(OpenShiftTemplateConstants.DROOLS_SERVER_FILTER_CLASSES, Boolean.toString(droolsFilter));
+        return this;
+    }
+
+    @Override
+    public KieServerSettingsBuilder withHostame(String http) {
+        envVariables.put(OpenShiftTemplateConstants.EXECUTION_SERVER_HOSTNAME_HTTP, http);
+        return this;
+    }
+
+    @Override
+    public KieServerSettingsBuilder withSecuredHostame(String https) {
+        envVariables.put(OpenShiftTemplateConstants.EXECUTION_SERVER_HOSTNAME_HTTPS, https);
         return this;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/settings/builder/SmartRouterSettingsBuilderImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/settings/builder/SmartRouterSettingsBuilderImpl.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.settings.builder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.settings.DeploymentSettings;
+import org.kie.cloud.api.settings.builder.SmartRouterSettingsBuilder;
+import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
+import org.kie.cloud.openshift.settings.DeploymentSettingsImpl;
+import org.kie.cloud.openshift.template.OpenShiftTemplate;
+
+public class SmartRouterSettingsBuilderImpl implements SmartRouterSettingsBuilder {
+
+    private Map<String, String> envVariables;
+    private final OpenShiftTemplate appTemplate = OpenShiftTemplate.SMARTROUTER;
+
+    public SmartRouterSettingsBuilderImpl() {
+        envVariables = new HashMap<>();
+
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser());
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
+    }
+
+    @Override
+    public DeploymentSettings build() {
+        return new DeploymentSettingsImpl(envVariables, appTemplate);
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder withApplicationName(String name) {
+        envVariables.put(OpenShiftTemplateConstants.APPLICATION_NAME, name);
+        return this;
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder withControllerUser(String username, String password) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, username);
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, password);
+        return this;
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder withSmartRouterID(String id) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_ID, id);
+        return this;
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder withSmartRouterName(String name) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_NAME, name);
+        return this;
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder withSmarRouterConfig(String host, String port) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_HOST, host);
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_PORT, port);
+        return this;
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder withControllerConnection(String host, String port) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_HOST, host);
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PORT, port);
+        return this;
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder withControllerConnection(String serviceName) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_SERVICE, serviceName);
+        return this;
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder withSmartRouterExternalUrl(String url) {
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_URL_EXTERNAL, url);
+        return this;
+    }
+
+    @Override
+    public SmartRouterSettingsBuilder withHostame(String http) {
+        envVariables.put(OpenShiftTemplateConstants.SMART_ROUTER_HOSTNAME_HTTP, http);
+        return this;
+    }
+
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/settings/builder/WorkbenchSettingsBuilderImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/settings/builder/WorkbenchSettingsBuilderImpl.java
@@ -35,6 +35,8 @@ public class WorkbenchSettingsBuilderImpl implements WorkbenchSettingsBuilder {
 
         envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
         envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser());
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
     }
 
     @Override
@@ -66,6 +68,18 @@ public class WorkbenchSettingsBuilderImpl implements WorkbenchSettingsBuilder {
     public WorkbenchSettingsBuilder withKieServerUser(String username, String password) {
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, username);
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, password);
+        return this;
+    }
+
+    @Override
+    public WorkbenchSettingsBuilder withHostame(String http) {
+        envVariables.put(OpenShiftTemplateConstants.BUSINESS_CENTRAL_HOSTNAME_HTTP, http);
+        return this;
+    }
+
+    @Override
+    public WorkbenchSettingsBuilder withSecuredHostame(String https) {
+        envVariables.put(OpenShiftTemplateConstants.BUSINESS_CENTRAL_HOSTNAME_HTTPS, https);
         return this;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/template/OpenShiftTemplate.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/template/OpenShiftTemplate.java
@@ -32,7 +32,8 @@ public enum OpenShiftTemplate {
     CONSOLE_SMARTROUTER(OpenShiftConstants.KIE_APP_TEMPLATE_CONSOLE_SMARTROUTER),
     CONSOLE(OpenShiftConstants.KIE_APP_TEMPLATE_CONSOLE),
     KIE_SERVER_S2I(OpenShiftConstants.KIE_APP_TEMPLATE_KIE_SERVER_S2I),
-    WORKBENCH(OpenShiftConstants.KIE_APP_TEMPLATE_WORKBENCH);
+    WORKBENCH(OpenShiftConstants.KIE_APP_TEMPLATE_WORKBENCH),
+    SMARTROUTER(OpenShiftConstants.KIE_APP_TEMPLATE_SMARTROUTER);
 
     private String templateSystemPropertyKey;
 

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -47,6 +47,8 @@
     <org.kie.workbench.pwd>adminUser1!</org.kie.workbench.pwd>
     <org.kie.server.controller.user>controllerUser</org.kie.server.controller.user>
     <org.kie.server.controller.pwd>controllerUser1!</org.kie.server.controller.pwd>
+
+    <default.domain.suffix/>
   </properties>
 
   <modules>
@@ -93,6 +95,7 @@
               <kie.app.template.kie-server.database.external>${kie.app.template.kie-server.database.external}</kie.app.template.kie-server.database.external>
               <kie.app.template.workbench-monitoring>${kie.app.template.workbench-monitoring}</kie.app.template.workbench-monitoring>
               <kie.app.template.workbench-monitoring.smartrouter>${kie.app.template.workbench-monitoring.smartrouter}</kie.app.template.workbench-monitoring.smartrouter>
+              <kie.app.template.smartrouter>${kie.app.template.smartrouter}</kie.app.template.smartrouter>
               <db.hostname>${db.hostname}</db.hostname>
               <db.port>${db.port}</db.port>
               <db.name>${db.name}</db.name>
@@ -115,6 +118,7 @@
               <org.kie.workbench.pwd>${org.kie.workbench.pwd}</org.kie.workbench.pwd>
               <org.kie.server.controller.user>${org.kie.server.controller.user}</org.kie.server.controller.user>
               <org.kie.server.controller.pwd>${org.kie.server.controller.pwd}</org.kie.server.controller.pwd>
+              <default.domain.suffix>${default.domain.suffix}</default.domain.suffix>
             </systemProperties>
           </configuration>
         </plugin>

--- a/test-cloud/src/main/resources/templates-general.properties
+++ b/test-cloud/src/main/resources/templates-general.properties
@@ -4,3 +4,4 @@ kie.app.template.workbench=https://raw.githubusercontent.com/jboss-openshift/app
 kie.app.template.workbench-monitoring=https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/bpmsuite/bpmsuite70-businesscentral-monitoring.json
 kie.app.template.workbench-monitoring.smartrouter=https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/bpmsuite/bpmsuite70-businesscentral-monitoring-with-smartrouter.json
 kie.app.template.kie-server.database.external=https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/bpmsuite/bpmsuite70-executionserver-externaldb.json
+kie.app.template.smartrouter=https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/bpmsuite/bpmsuite70-smartrouter.json


### PR DESCRIPTION
Smart router template file doesn't exists yet, PR for Smart router template is open [here](https://github.com/jboss-openshift/application-templates/pull/400). Now you can try to use template from pull request - replace kie.app.template.smartrouter in templates-general.properties https://raw.githubusercontent.com/jakubschwan/application-templates/bpmsuite-wip-smartrouter-template/bpmsuite/bpmsuite70-smartrouter.json

Added a new property to set the domain name - default.domain.suffix. Into maven add property `-Ddefault.domain.suffix=.project.openshiftdomain`

 Smart router location configuration in builder:
`smartRouter = deploymentScenarioFactory.getSmartRouterSettingsBuilder()`
`    .withApplicationName(SMART_ROUTER_NAME)`
`    .withHostame(SMART_ROUTER_NAME + DeploymentConstants.getDefaultDomainSuffix())`
`    .withSmartRouterExternalUrl("http://" + SMART_ROUTER_NAME + DeploymentConstants.getDefaultDomainSuffix() + ":80")`
`    .build();`


