### PR TITLE
Adjust WorkbenchHttpsIntegrationTest to test several scenarios

### DIFF
--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
@@ -43,6 +43,14 @@ public class OpenShiftConstants implements Constants {
      */
     public static final String KIE_APP_SECRET = "kie.app.secret";
     /**
+     * URL pointing to OpenShift resource file containing Workbench keystore for HTTPS communication.
+     */
+    public static final String KIE_APP_WORKBENCH_SECRET = "kie.app.workbench.secret";
+    /**
+     * URL pointing to OpenShift resource file containing Kie server keystore for HTTPS communication.
+     */
+    public static final String KIE_APP_KIE_SERVER_SECRET = "kie.app.kie-server.secret";
+    /**
      * URL pointing to OpenShift resource file containing image streams with all available images.
      */
     public static final String KIE_IMAGE_STREAMS = "kie.image.streams";
@@ -105,6 +113,14 @@ public class OpenShiftConstants implements Constants {
 
     public static String getKieAppSecret() {
         return System.getProperty(KIE_APP_SECRET);
+    }
+
+    public static String getKieAppWorkbenchSecret() {
+        return System.getProperty(KIE_APP_WORKBENCH_SECRET);
+    }
+
+    public static String getKieAppKieServerSecret() {
+        return System.getProperty(KIE_APP_KIE_SERVER_SECRET);
     }
 
     public static String getKieImageStreams() {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioImpl.java
@@ -70,8 +70,11 @@ public class WorkbenchKieServerScenarioImpl implements WorkbenchKieServerScenari
         logger.info("Creating project " + projectName);
         Project project = openshiftController.createProject(projectName);
 
-        logger.info("Creating secrets from " + OpenShiftConstants.getKieAppSecret());
-        project.createResources(OpenShiftConstants.getKieAppSecret());
+        logger.info("Creating secrets from " + OpenShiftConstants.getKieAppWorkbenchSecret());
+        project.createResources(OpenShiftConstants.getKieAppWorkbenchSecret());
+
+        logger.info("Creating secrets from " + OpenShiftConstants.getKieAppKieServerSecret());
+        project.createResources(OpenShiftConstants.getKieAppKieServerSecret());
 
         logger.info("Creating image streams from " + OpenShiftConstants.getKieImageStreams());
         project.createResources(OpenShiftConstants.getKieImageStreams());

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -23,6 +23,8 @@
 
     <kie.image.streams/> <!-- Needs to be defined for proper test run. -->
     <kie.app.secret>https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/secrets/bpmsuite-app-secret.json</kie.app.secret>
+    <kie.app.workbench.secret>https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/rhdm70-dev/decisioncentral-app-secret.yaml</kie.app.workbench.secret>
+    <kie.app.kie-server.secret>https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/rhdm70-dev/kieserver-app-secret.yaml</kie.app.kie-server.secret>
     <!-- Templates are specified in specific properties files. Path is relative to submodules of this module. -->
     <kie.app.templates.general>${project.parent.build.resources[0].directory}/templates-general.properties</kie.app.templates.general>
     <kie.app.templates.mysql>${project.parent.build.resources[0].directory}/templates-mysql.properties</kie.app.templates.mysql>
@@ -85,6 +87,8 @@
               <openshift.username>${openshift.username}</openshift.username>
               <openshift.password>${openshift.password}</openshift.password>
               <kie.app.secret>${kie.app.secret}</kie.app.secret>
+              <kie.app.workbench.secret>${kie.app.workbench.secret}</kie.app.workbench.secret>
+              <kie.app.kie-server.secret>${kie.app.kie-server.secret}</kie.app.kie-server.secret>
               <kie.image.streams>${kie.image.streams}</kie.image.streams>
               <!-- All templates have to be passed as properties to failsafe plugin. -->
               <kie.app.template.workbench>${kie.app.template.workbench}</kie.app.template.workbench>

--- a/test-cloud/src/main/resources/templates-general.properties
+++ b/test-cloud/src/main/resources/templates-general.properties
@@ -5,3 +5,4 @@ kie.app.template.workbench-monitoring=https://raw.githubusercontent.com/jboss-op
 kie.app.template.workbench-monitoring.smartrouter=https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/bpmsuite/bpmsuite70-businesscentral-monitoring-with-smartrouter.json
 kie.app.template.kie-server.database.external=https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/bpmsuite/bpmsuite70-executionserver-externaldb.json
 kie.app.template.smartrouter=https://raw.githubusercontent.com/jboss-openshift/application-templates/bpmsuite-wip/bpmsuite/bpmsuite70-smartrouter.json
+kie.app.template.workbench.kie-server=https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/rhdm70-dev/templates/rhdm70-full.yaml

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/https/WorkbenchHttpsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/https/WorkbenchHttpsIntegrationTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.stream.StreamSupport;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -34,13 +36,23 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
+import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.scenario.WorkbenchKieServerDatabaseScenario;
+import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WorkbenchHttpsIntegrationTest extends AbstractCloudIntegrationTest<WorkbenchKieServerDatabaseScenario> {
+@RunWith(Parameterized.class)
+public class WorkbenchHttpsIntegrationTest extends AbstractCloudIntegrationTest<WorkbenchKieServerScenario> {
+
+    @Parameter
+    public WorkbenchKieServerScenario workbenchKieServerScenario;
 
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchHttpsIntegrationTest.class);
 
@@ -51,9 +63,21 @@ public class WorkbenchHttpsIntegrationTest extends AbstractCloudIntegrationTest<
     private static final String SERVER_ID = "KieServerId";
     private static final String SERVER_NAME = "KieServer";
 
+    @Parameters
+    public static Collection<Object[]> data() {
+        DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactoryLoader.getInstance();
+
+        WorkbenchKieServerScenario workbenchKieServerScenario = deploymentScenarioFactory.getWorkbenchKieServerScenarioBuilder().build();
+        WorkbenchKieServerDatabaseScenario workbenchKieServerDatabaseScenario = deploymentScenarioFactory.getWorkbenchKieServerDatabaseScenarioBuilder().build();
+
+        return Arrays.asList(new Object[][] {
+                 { workbenchKieServerScenario }, {workbenchKieServerDatabaseScenario }
+           });
+    }
+
     @Override
-    protected WorkbenchKieServerDatabaseScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        return deploymentScenarioFactory.getWorkbenchKieServerDatabaseScenarioBuilder().build();
+    protected WorkbenchKieServerScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
+        return workbenchKieServerScenario;
     }
 
     @Test


### PR DESCRIPTION
Please take a look and say your opinion about this approach. Intent is to be able to use same test for several scenarios/products.
Will it be better to create separate template properties file for DM?
Will update the PR when https://github.com/jboss-container-images/rhdm-7-openshift-image/pull/6 will be merged.