### PR TITLE
Fix ReadinessProbeIntegrationTest

### DIFF
--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
@@ -127,6 +127,7 @@ public class ReadinessProbeIntegrationTest extends AbstractCloudIntegrationTest<
 
         checkBCLoginScreenAvailable();
         logger.debug("Check that workbench REST is available");
+        workbenchClient = WorkbenchClientProvider.getWorkbenchClient(deploymentScenario.getWorkbenchDeployment());
         workbenchClient.createSpace(SPACE_SECOND_NAME, deploymentScenario.getWorkbenchDeployment().getUsername());
         spaces = workbenchClient.getSpaces();
         Assertions.assertThat(spaces.stream().anyMatch(x -> x.getName().equals(SPACE_SECOND_NAME))).isTrue();


### PR DESCRIPTION
It seems that Workbench client doesn't handle pod restarts well. Fixed by creating of new client to work with restarted pod.