### PR TITLE
Process and create template using oc client

### DIFF
--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl.java
@@ -36,6 +36,8 @@ public class ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl implements
         envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser());
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl.java
@@ -38,6 +38,8 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
         envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
         envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser());
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
@@ -50,14 +50,6 @@ public interface Project extends AutoCloseable {
     public void processTemplateAndCreateResources(URL templateUrl, Map<String, String> envVariables);
 
     /**
-     * Process template and create all resources defined there.
-     *
-     * @param templateInputStream Input stream with template to be processed
-     * @param envVariables Map of environment variables to override default values from the template
-     */
-    public void processTemplateAndCreateResources(InputStream templateInputStream, Map<String, String> envVariables);
-
-    /**
      * Create all resources defined in resource URL.
      *
      * @param resourceUrl URL of resource list to be created

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/SsoDeployer.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/SsoDeployer.java
@@ -15,21 +15,21 @@
  */
 package org.kie.cloud.openshift.util;
 
-import cz.xtf.sso.api.SsoApi;
-import cz.xtf.sso.api.SsoApiFactory;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import cz.xtf.sso.api.SsoApi;
+import cz.xtf.sso.api.SsoApiFactory;
+import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
+import org.kie.cloud.openshift.constants.SsoTemplateConstants;
 import org.kie.cloud.openshift.deployment.SsoDeploymentImpl;
 import org.kie.cloud.openshift.resource.Project;
 import org.kie.cloud.openshift.template.OpenShiftTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.kie.cloud.api.deployment.SsoDeployment;
-import org.kie.cloud.openshift.constants.SsoTemplateConstants;
 
 public class SsoDeployer {
 
@@ -41,7 +41,7 @@ public class SsoDeployer {
         SsoDeployment ssoDeployment = createSsoDeployment(project);
 
         logger.info("Creating SSO secrets from " + OpenShiftTemplate.SSO_SECRET.getTemplateUrl().toString());
-        project.processTemplateAndCreateResources(OpenShiftTemplate.SSO_SECRET.getTemplateUrl(), Collections.emptyMap());
+        project.createResources(OpenShiftTemplate.SSO_SECRET.getTemplateUrl().toExternalForm());
         logger.info("Creating SSO image streams from " + OpenShiftConstants.getSsoImageStreams());
         project.createResources(OpenShiftConstants.getSsoImageStreams());
 


### PR DESCRIPTION
Workaround for fabric8 client limitation - cannot handle template placeholders for fields expecting numeric value.
Also deleted processTemplateAndCreateResources which shouldn't be used anywhere.

It shouldn't have any side effect.