### PR TITLE
Raise timeout for image version check

### DIFF
--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ImageVersionIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ImageVersionIntegrationTest.java
@@ -66,7 +66,7 @@ public class ImageVersionIntegrationTest extends AbstractMethodIsolatedCloudInte
     private String getImageVersion(Deployment deployment) {
         CommandExecutionResult checkVersionCommand = deployment.getInstances().get(0).runCommand("grep", "-r", KIE_API_ARTIFACT_NAME, DEPLOYMENT_PATH);
 
-        TimeUtils.wait(Duration.ofSeconds(3), Duration.ofSeconds(1), () -> checkVersionCommand.getOutput().contains(KIE_VERSION));
+        TimeUtils.wait(Duration.ofSeconds(10), Duration.ofSeconds(1), () -> checkVersionCommand.getOutput().contains(KIE_VERSION));
 
         return getArtifactVersion(checkVersionCommand.getOutput());
     }


### PR DESCRIPTION
The low timeout brought test instability.
Skipped CI as the 7.3 images are not yet available.