### PR TITLE
[PLANNER-1206] Develop automation to test Employee Rostering application on OpenShift

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/DeploymentScenarioBuilderFactory.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/DeploymentScenarioBuilderFactory.java
@@ -18,6 +18,7 @@ package org.kie.cloud.api;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchKieServerPersistentScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder;
+import org.kie.cloud.api.scenario.builder.EmployeeRosteringScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.GenericScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.KieServerWithDatabaseScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.KieServerWithExternalDatabaseScenarioBuilder;
@@ -54,6 +55,7 @@ public interface DeploymentScenarioBuilderFactory {
     SmartRouterSettingsBuilder getSmartRouterSettingsBuilder();
 
     LdapSettingsBuilder getLdapSettingsBuilder();
+    EmployeeRosteringScenarioBuilder getEmployeeRosteringScenarioBuilder();
 
     void deleteNamespace(String namespace);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/EmployeeRosteringDeployment.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/EmployeeRosteringDeployment.java
@@ -1,0 +1,16 @@
+package org.kie.cloud.api.deployment;
+
+import java.net.URL;
+
+/**
+ * optaweb-employee-rostering application
+ */
+public interface EmployeeRosteringDeployment extends Deployment {
+
+    /**
+     * Get URL for Optaweb Employee Rostering service (deployment).
+     *
+     * @return Kie Server URL
+     */
+    URL getUrl();
+}

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/EmployeeRosteringDeployment.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/EmployeeRosteringDeployment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.cloud.api.deployment;
 
 import java.net.URL;

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/ClusteredWorkbenchKieServerDatabasePersistentScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/ClusteredWorkbenchKieServerDatabasePersistentScenario.java
@@ -23,7 +23,7 @@ import org.kie.cloud.api.deployment.WorkbenchDeployment;
 /**
  * Representation of deployment scenario with clustered Workbench and Kie server.
  */
-public interface ClusteredWorkbenchKieServerDatabasePersistentScenario extends DeploymentScenario {
+public interface ClusteredWorkbenchKieServerDatabasePersistentScenario extends KieDeploymentScenario {
 
     /**
      * Return Workbench deployment.

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/ClusteredWorkbenchKieServerPersistentScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/ClusteredWorkbenchKieServerPersistentScenario.java
@@ -22,7 +22,7 @@ import org.kie.cloud.api.deployment.WorkbenchDeployment;
 /**
  * Representation of deployment scenario with clustered Workbench and Kie server.
  */
-public interface ClusteredWorkbenchKieServerPersistentScenario extends DeploymentScenario {
+public interface ClusteredWorkbenchKieServerPersistentScenario extends KieDeploymentScenario {
 
     /**
      * Return Workbench deployment.

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario.java
@@ -24,7 +24,7 @@ import org.kie.cloud.api.deployment.WorkbenchDeployment;
 /**
  * Representation of deployment scenario with clustered Workbench Runtime, Smart router, two Kie servers and two databases.
  */
-public interface ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario extends DeploymentScenario {
+public interface ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario extends KieDeploymentScenario {
 
     /**
      * Return Workbench deployment.

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/DeploymentScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/DeploymentScenario.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.cloud.api.scenario;
 
 import java.util.List;

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/DeploymentScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/DeploymentScenario.java
@@ -1,34 +1,11 @@
-/*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-*/
-
 package org.kie.cloud.api.scenario;
 
 import java.util.List;
 
 import org.kie.cloud.api.deployment.Deployment;
 import org.kie.cloud.api.deployment.DeploymentTimeoutException;
-import org.kie.cloud.api.deployment.KieServerDeployment;
-import org.kie.cloud.api.deployment.SmartRouterDeployment;
-import org.kie.cloud.api.deployment.WorkbenchDeployment;
-import org.kie.cloud.api.deployment.ControllerDeployment;
 
-/**
- * Cloud deployment scenario representation.
- */
 public interface DeploymentScenario {
-
     /**
      * Return deployment scenario namespace.
      *
@@ -70,40 +47,4 @@ public interface DeploymentScenario {
      * @return All available deployments.
      */
     List<Deployment> getDeployments();
-
-    /**
-     * Return List of all Workbench deployments. If there aren't any deployment,
-     * then is returned empty list.
-     *
-     * @return WorkbenchDeployments
-     * @see WorkbenchDeployment
-     */
-    List<WorkbenchDeployment> getWorkbenchDeployments();
-
-    /**
-     * Return List of all Kie Server deployments. If there aren't any
-     * deployment, then is returned empty list.
-     *
-     * @return KieServerDeployments
-     * @see KieServerDeployment
-     */
-    List<KieServerDeployment> getKieServerDeployments();
-
-    /**
-     * Return List of all Smart Router deployments. If there aren't any
-     * deployment, then is returned empty list.
-     *
-     * @return SmartRouterDeployments
-     * @see SmartRouterDeployment
-     */
-    List<SmartRouterDeployment> getSmartRouterDeployments();
-
-    /**
-     * Return List of all Controller deployments. If there aren't any
-     * deployment, then is returned empty list.
-     *
-     * @return ControllerDeployments
-     * @see ControllerDeployment
-     */
-    List<ControllerDeployment> getControllerDeployments();
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/EmployeeRosteringScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/EmployeeRosteringScenario.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cloud.api.scenario;
 
 import org.kie.cloud.api.deployment.EmployeeRosteringDeployment;

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/EmployeeRosteringScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/EmployeeRosteringScenario.java
@@ -1,0 +1,8 @@
+package org.kie.cloud.api.scenario;
+
+import org.kie.cloud.api.deployment.EmployeeRosteringDeployment;
+
+public interface EmployeeRosteringScenario extends DeploymentScenario {
+
+    EmployeeRosteringDeployment getEmployeeRosteringDeployment();
+}

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/GenericScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/GenericScenario.java
@@ -18,6 +18,6 @@ package org.kie.cloud.api.scenario;
 /**
  * Cloud generic deployment scenario representation.
  */
-public interface GenericScenario extends DeploymentScenario {
+public interface GenericScenario extends KieDeploymentScenario {
 
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieDeploymentScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieDeploymentScenario.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.cloud.api.scenario;
+
+import java.util.List;
+
+import org.kie.cloud.api.deployment.KieServerDeployment;
+import org.kie.cloud.api.deployment.SmartRouterDeployment;
+import org.kie.cloud.api.deployment.WorkbenchDeployment;
+import org.kie.cloud.api.deployment.ControllerDeployment;
+
+/**
+ * Cloud deployment scenario representation.
+ */
+public interface KieDeploymentScenario extends DeploymentScenario {
+
+    /**
+     * Return List of all Workbench deployments. If there aren't any deployment,
+     * then is returned empty list.
+     *
+     * @return WorkbenchDeployments
+     * @see WorkbenchDeployment
+     */
+    List<WorkbenchDeployment> getWorkbenchDeployments();
+
+    /**
+     * Return List of all Kie Server deployments. If there aren't any
+     * deployment, then is returned empty list.
+     *
+     * @return KieServerDeployments
+     * @see KieServerDeployment
+     */
+    List<KieServerDeployment> getKieServerDeployments();
+
+    /**
+     * Return List of all Smart Router deployments. If there aren't any
+     * deployment, then is returned empty list.
+     *
+     * @return SmartRouterDeployments
+     * @see SmartRouterDeployment
+     */
+    List<SmartRouterDeployment> getSmartRouterDeployments();
+
+    /**
+     * Return List of all Controller deployments. If there aren't any
+     * deployment, then is returned empty list.
+     *
+     * @return ControllerDeployments
+     * @see ControllerDeployment
+     */
+    List<ControllerDeployment> getControllerDeployments();
+}

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieServerWithDatabaseScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieServerWithDatabaseScenario.java
@@ -22,7 +22,7 @@ import org.kie.cloud.api.deployment.SsoDeployment;
 /**
  * Representation of deployment scenario with Kie server and external database.
  */
-public interface KieServerWithDatabaseScenario extends DeploymentScenario {
+public interface KieServerWithDatabaseScenario extends KieDeploymentScenario {
 
     /**
      * Return Kie Server deployment.

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieServerWithExternalDatabaseScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieServerWithExternalDatabaseScenario.java
@@ -20,7 +20,7 @@ import org.kie.cloud.api.deployment.KieServerDeployment;
 /**
  * Representation of deployment scenario with Kie server and external database.
  */
-public interface KieServerWithExternalDatabaseScenario extends DeploymentScenario {
+public interface KieServerWithExternalDatabaseScenario extends KieDeploymentScenario {
 
     /**
      * Return Kie Server deployment.

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/WorkbenchKieServerScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/WorkbenchKieServerScenario.java
@@ -21,7 +21,7 @@ import org.kie.cloud.api.deployment.WorkbenchDeployment;
 /**
  * Representation of deployment scenario with Workbench and Kie server.
  */
-public interface WorkbenchKieServerScenario extends DeploymentScenario {
+public interface WorkbenchKieServerScenario extends KieDeploymentScenario {
 
     /**
      * Return Workbench deployment.

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/DeploymentScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/DeploymentScenarioBuilder.java
@@ -15,10 +15,12 @@
 
 package org.kie.cloud.api.scenario.builder;
 
+import org.kie.cloud.api.scenario.KieDeploymentScenario;
+
 /**
  * Cloud deployment scenario builder. Create setup for Deployment scenario.
  *
- * @see org.kie.cloud.api.scenario.DeploymentScenario
+ * @see KieDeploymentScenario
  *
  * @param <T> Setup to be built e.g. WorkbenchKieServerDatabaseScenario
  * @see org.kie.cloud.api.scenario.WorkbenchKieServerDatabaseScenario

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/EmployeeRosteringScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/EmployeeRosteringScenarioBuilder.java
@@ -1,0 +1,7 @@
+package org.kie.cloud.api.scenario.builder;
+
+import org.kie.cloud.api.scenario.EmployeeRosteringScenario;
+
+public interface EmployeeRosteringScenarioBuilder extends DeploymentScenarioBuilder<EmployeeRosteringScenario> {
+
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/OperatorDeploymentBuilderFactory.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/OperatorDeploymentBuilderFactory.java
@@ -19,6 +19,7 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchKieServerPersistentScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder;
+import org.kie.cloud.api.scenario.builder.EmployeeRosteringScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.GenericScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.KieServerWithDatabaseScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.KieServerWithExternalDatabaseScenarioBuilder;
@@ -134,6 +135,11 @@ public class OperatorDeploymentBuilderFactory implements DeploymentScenarioBuild
 
     @Override
     public LdapSettingsBuilder getLdapSettingsBuilder() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public EmployeeRosteringScenarioBuilder getEmployeeRosteringScenarioBuilder() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/TemplatesDeploymentBuilderFactory.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/TemplatesDeploymentBuilderFactory.java
@@ -19,6 +19,7 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchKieServerPersistentScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder;
+import org.kie.cloud.api.scenario.builder.EmployeeRosteringScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.GenericScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.KieServerWithDatabaseScenarioBuilder;
 import org.kie.cloud.api.scenario.builder.KieServerWithExternalDatabaseScenarioBuilder;
@@ -34,6 +35,7 @@ import org.kie.cloud.api.settings.builder.WorkbenchSettingsBuilder;
 import org.kie.cloud.openshift.scenario.builder.ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl;
 import org.kie.cloud.openshift.scenario.builder.ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl;
 import org.kie.cloud.openshift.scenario.builder.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl;
+import org.kie.cloud.openshift.scenario.builder.EmployeeRosteringScenarioBuilderImpl;
 import org.kie.cloud.openshift.scenario.builder.GenericScenarioBuilderImpl;
 import org.kie.cloud.openshift.scenario.builder.KieServerWithExternalDatabaseScenarioBuilderImpl;
 import org.kie.cloud.openshift.scenario.builder.KieServerWithMySqlScenarioBuilderImpl;
@@ -150,6 +152,11 @@ public class TemplatesDeploymentBuilderFactory implements DeploymentScenarioBuil
     @Override
     public LdapSettingsBuilder getLdapSettingsBuilder() {
         return new LdapSettingsBuilderImpl();
+    }
+
+    @Override
+    public EmployeeRosteringScenarioBuilder getEmployeeRosteringScenarioBuilder() {
+        return new EmployeeRosteringScenarioBuilderImpl();
     }
 
     @Override

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/OpenShiftTemplateConstants.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/OpenShiftTemplateConstants.java
@@ -15,6 +15,7 @@
 
 package org.kie.cloud.openshift.constants;
 
+// TODO: these constants should be rather put into classes responsible for respective components
 public class OpenShiftTemplateConstants {
 
     // Used as a generic password for all passwords in the template (Workbench user, Kie server user, Controller user, Workbench maven user)

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/EmployeeRosteringScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/EmployeeRosteringScenarioImpl.java
@@ -1,0 +1,51 @@
+package org.kie.cloud.openshift.scenario;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kie.cloud.api.deployment.Deployment;
+import org.kie.cloud.api.deployment.EmployeeRosteringDeployment;
+import org.kie.cloud.api.scenario.EmployeeRosteringScenario;
+import org.kie.cloud.openshift.constants.OpenShiftConstants;
+import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
+import org.kie.cloud.openshift.deployment.EmployeeRosteringDeploymentImpl;
+import org.kie.cloud.openshift.template.OpenShiftTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EmployeeRosteringScenarioImpl extends OpenShiftScenario implements EmployeeRosteringScenario {
+
+    private static final String OPTAWEB_HTTPS_SECRET = "OPTAWEB_HTTPS_SECRET";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmployeeRosteringScenarioImpl.class);
+
+    private EmployeeRosteringDeployment employeeRosteringDeployment;
+
+    @Override
+    public void deploy() {
+        super.deploy();
+
+        this.employeeRosteringDeployment = new EmployeeRosteringDeploymentImpl(project);
+
+        Map<String, String> env = new HashMap<>();
+        env.put(OpenShiftTemplateConstants.IMAGE_STREAM_NAMESPACE, project.getName());
+        env.put(OPTAWEB_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
+
+        project.processTemplateAndCreateResources(OpenShiftTemplate.OPTAWEB_EMPLOYEE_ROSTERING.getTemplateUrl(), env);
+
+        LOGGER.info("Waiting for OptaWeb Employee Rostering deployment to become ready.");
+        employeeRosteringDeployment.waitForScale();
+        LOGGER.info("Waiting for OptaWeb Employee Rostering has been deployed.");
+    }
+
+    @Override
+    public List<Deployment> getDeployments() {
+        return Collections.singletonList(employeeRosteringDeployment);
+    }
+
+    public EmployeeRosteringDeployment getEmployeeRosteringDeployment() {
+        return this.employeeRosteringDeployment;
+    }
+}

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/EmployeeRosteringScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/EmployeeRosteringScenarioImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cloud.openshift.scenario;
 
 import java.util.Collections;

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/EmployeeRosteringScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/EmployeeRosteringScenarioBuilderImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.cloud.openshift.scenario.builder;
 
 import org.kie.cloud.api.scenario.EmployeeRosteringScenario;

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/EmployeeRosteringScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/EmployeeRosteringScenarioBuilderImpl.java
@@ -1,0 +1,13 @@
+package org.kie.cloud.openshift.scenario.builder;
+
+import org.kie.cloud.api.scenario.EmployeeRosteringScenario;
+import org.kie.cloud.api.scenario.builder.EmployeeRosteringScenarioBuilder;
+import org.kie.cloud.openshift.scenario.EmployeeRosteringScenarioImpl;
+
+public class EmployeeRosteringScenarioBuilderImpl implements EmployeeRosteringScenarioBuilder {
+
+    @Override
+    public EmployeeRosteringScenario build() {
+        return new EmployeeRosteringScenarioImpl();
+    }
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
@@ -129,6 +129,11 @@ public class OpenShiftConstants implements Constants {
 
     public static final String KIE_APP_TEMPLATE_PROD_IMMUTABLE_MONITOR = "kie.app.template.prod.immutable.monitor";
 
+    /**
+     * A key pointing to a URL to OpenShift template for optaweb-employee-rostering app.
+     */
+    public static final String OPTAWEB_EMPLOYEE_ROSTERING_TEMPLATE = "kie.app.template.optaweb.employee-rostering";
+
     public static final String SSO_APP_TEMPLATE ="sso.app.template";
     public static final String SSO_APP_SECRETS = "sso.app.secrets";
     public static final String SSO_IMAGE_STREAMS = "sso.image.streams";

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/EmployeeRosteringDeploymentImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/EmployeeRosteringDeploymentImpl.java
@@ -1,0 +1,26 @@
+package org.kie.cloud.openshift.deployment;
+
+import java.net.URL;
+import java.util.regex.Pattern;
+
+import org.kie.cloud.api.deployment.EmployeeRosteringDeployment;
+import org.kie.cloud.openshift.resource.Project;
+
+public class EmployeeRosteringDeploymentImpl extends OpenShiftDeployment implements EmployeeRosteringDeployment {
+
+    private static final Pattern PATTERN = Pattern.compile(".*-optaweb-employee-rostering");
+
+    public EmployeeRosteringDeploymentImpl(final Project project) {
+        super(project);
+    }
+
+    @Override
+    public URL getUrl() {
+        return getHttpRouteUrl(getServiceName());
+    }
+
+    @Override
+    public String getServiceName() {
+        return ServiceUtil.getServiceName(getOpenShiftUtil(), PATTERN);
+    }
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/ServiceUtil.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/ServiceUtil.java
@@ -23,7 +23,7 @@ import cz.xtf.openshift.OpenShiftUtil;
 import io.fabric8.kubernetes.api.model.Service;
 
 public class ServiceUtil {
-
+    //TODO: regex patterns should be rather moved into the Deployment? classes responsible for individual applications
     private static final Pattern CONTROLLER_REGEXP = Pattern.compile("(?!secure-).*-controller");
     private static final Pattern WORKBENCH_REGEXP = Pattern.compile("(?!secure-).*(-rhpamcentr|-rhdmcentr)");
     private static final Pattern WORKBENCH_MONITORING_REGEXP = Pattern.compile("(?!secure-).*-rhpamcentrmon");
@@ -60,7 +60,7 @@ public class ServiceUtil {
         return getServiceName(util, DOCKER_REGEXP);
     }
 
-    private static String getServiceName(OpenShiftUtil util, Pattern regexp) {
+    public static String getServiceName(OpenShiftUtil util, Pattern regexp) {
         // Try to find service name from all available services
         List<Service> services = util.getServices();
         for (Service service : services) {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/template/OpenShiftTemplate.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/template/OpenShiftTemplate.java
@@ -43,7 +43,8 @@ public enum OpenShiftTemplate {
     SSO(OpenShiftConstants.SSO_APP_TEMPLATE),
     // Special template containing secret file.
     SECRET(OpenShiftConstants.KIE_APP_SECRET),
-    SSO_SECRET(OpenShiftConstants.SSO_APP_SECRETS);
+    SSO_SECRET(OpenShiftConstants.SSO_APP_SECRETS),
+    OPTAWEB_EMPLOYEE_ROSTERING(OpenShiftConstants.OPTAWEB_EMPLOYEE_ROSTERING_TEMPLATE);
 
     private static final Properties templateProperties = OpenShiftTemplatePropertiesLoader.getProperties();
 

--- a/framework-cloud/framework-openshift/src/main/resources/org/kie/cloud/openshift/template/templates-drools.properties
+++ b/framework-cloud/framework-openshift/src/main/resources/org/kie/cloud/openshift/template/templates-drools.properties
@@ -4,3 +4,7 @@ kie.app.template.kie-server-https-s2i=${kie.app.template.url}/rhdm${rhba.images.
 kie.app.template.workbench.kie-server.persistent=${kie.app.template.url}/rhdm${rhba.images.version.prefix}-authoring.yaml
 kie.app.template.workbench.kie-server=${kie.app.template.url}/rhdm${rhba.images.version.prefix}-trial-ephemeral.yaml
 kie.app.template.clustered-workbench.kieserver=${kie.app.template.url}/rhdm${rhba.images.version.prefix}-authoring-ha.yaml
+
+# Before the postgresql template is ready
+kie.app.template.optaweb.employee-rostering=${kie.app.template.url}/optaweb/rhdm${rhba.images.version.prefix}-optaweb-employee-rostering-trial-ephemeral.yaml
+#kie.app.template.optaweb.employee-rostering=${kie.app.template.url}/optaweb/rhdm${rhba.images.version.prefix}-optaweb-employee-rostering-postgresql.yaml

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <rhba.images.version.prefix>72</rhba.images.version.prefix>
-    <rhba.images.branch>master</rhba.images.branch>
+    <rhba.images.branch>7.2.x</rhba.images.branch>
 
     <findbugs.failOnViolation>true</findbugs.failOnViolation>
     <checkstyle.failOnViolation>false</checkstyle.failOnViolation>
@@ -215,6 +215,21 @@
         <groupId>org.jboss</groupId>
         <artifactId>jboss-dmr</artifactId>
         <version>${version.org.jboss.jboss-dmr}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaweb.employeerostering</groupId>
+        <artifactId>employee-rostering-shared</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaweb.employeerostering</groupId>
+        <artifactId>employee-rostering-restclient</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-persistence-jackson</artifactId>
+        <version>${version.org.kie}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
         <version>${version.org.kie}</version>
       </dependency>
       <dependency>
+        <groupId>org.kie.cloud</groupId>
+        <artifactId>test-cloud-common</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
         <groupId>org.kie.server</groupId>
         <artifactId>kie-server-integ-tests-common</artifactId>
         <version>${version.org.kie}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <rhba.images.version.prefix>72</rhba.images.version.prefix>
-    <rhba.images.branch>7.2.x</rhba.images.branch>
+    <rhba.images.branch>master</rhba.images.branch>
 
     <findbugs.failOnViolation>true</findbugs.failOnViolation>
     <checkstyle.failOnViolation>false</checkstyle.failOnViolation>

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -77,7 +77,9 @@
   </properties>
 
   <modules>
+    <module>test-cloud-common</module>
     <module>test-cloud-remote</module>
+    <module>test-cloud-optaweb</module>
   </modules>
 
   <build>
@@ -226,6 +228,61 @@
                 <files>
                   <file>${custom.parameters.file}</file>
                 </files>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>openshift</id>
+      <properties>
+        <skipTests>false</skipTests>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.kie.cloud</groupId>
+          <artifactId>framework-openshift</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.kie.cloud</groupId>
+          <artifactId>framework-openshift-templates</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>openshift-operator</id>
+      <properties>
+        <skipTests>false</skipTests>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.kie.cloud</groupId>
+          <artifactId>framework-openshift</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.kie.cloud</groupId>
+          <artifactId>framework-openshift-operator</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>parallel</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <parallel>suitesAndClasses</parallel>
+                <threadCountClasses>3</threadCountClasses>
+                <threadCountSuites>2</threadCountSuites>
+                <perCoreThreadCount>false</perCoreThreadCount>
               </configuration>
             </plugin>
           </plugins>

--- a/test-cloud/test-cloud-common/pom.xml
+++ b/test-cloud/test-cloud-common/pom.xml
@@ -21,10 +21,6 @@
       <artifactId>framework-cloud-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie.cloud</groupId>
-      <artifactId>framework-git</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/test-cloud/test-cloud-common/pom.xml
+++ b/test-cloud/test-cloud-common/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>test-cloud</artifactId>
+    <groupId>org.kie.cloud</groupId>
+    <version>7.17.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.kie.cloud</groupId>
+  <artifactId>test-cloud-common</artifactId>
+
+  <name>KIE :: Cloud :: Common Test</name>
+  <description>Module providing test utilities and parent test classes.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kie.cloud</groupId>
+      <artifactId>framework-cloud-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.cloud</groupId>
+      <artifactId>framework-git</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractCloudIntegrationTest.java
@@ -17,8 +17,6 @@ package org.kie.cloud.tests.common;
 
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
-import org.kie.cloud.git.GitProvider;
-import org.kie.cloud.git.GitProviderService;
 
 public abstract class AbstractCloudIntegrationTest {
 
@@ -54,13 +52,4 @@ public abstract class AbstractCloudIntegrationTest {
     protected static final String PROJECT_SOURCE_FOLDER = "/kjars-sources";
 
     protected static final DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactoryLoader.getInstance();
-
-    private GitProvider gitProvider;
-
-    protected GitProvider getGitProvider() {
-        if (gitProvider == null) {
-            gitProvider = new GitProviderService().createGitProvider();
-        }
-        return gitProvider;
-    }
 }

--- a/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractCloudIntegrationTest.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.kie.cloud.integrationtests;
+package org.kie.cloud.tests.common;
 
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;

--- a/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractMethodIsolatedCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractMethodIsolatedCloudIntegrationTest.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.kie.cloud.integrationtests;
+package org.kie.cloud.tests.common;
 
 import org.junit.After;
 import org.junit.Before;
@@ -21,7 +21,6 @@ import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.scenario.DeploymentScenario;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
 
 public abstract class AbstractMethodIsolatedCloudIntegrationTest<T extends DeploymentScenario> extends AbstractCloudIntegrationTest {
 
@@ -32,7 +31,7 @@ public abstract class AbstractMethodIsolatedCloudIntegrationTest<T extends Deplo
 
     @Before
     public void initializeDeployment() {
-        deploymentScenario = createDeploymentScenario(deploymentScenarioFactory);
+        deploymentScenario = createDeploymentScenario(AbstractCloudIntegrationTest.deploymentScenarioFactory);
         deploymentScenario.setLogFolderName(testName.getMethodName());
 
         ScenarioDeployer.deployScenario(deploymentScenario);

--- a/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/ScenarioDeployer.java
+++ b/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/ScenarioDeployer.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.kie.cloud.integrationtests.util;
+package org.kie.cloud.tests.common;
 
 import org.junit.Assume;
 import org.kie.cloud.api.deployment.DeploymentTimeoutException;

--- a/test-cloud/test-cloud-optaweb/pom.xml
+++ b/test-cloud/test-cloud-optaweb/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>test-cloud</artifactId>
+    <groupId>org.kie.cloud</groupId>
+    <version>7.17.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.kie.cloud</groupId>
+  <artifactId>test-cloud-optaweb</artifactId>
+
+  <name>KIE :: Cloud :: Optaweb Tests</name>
+  <description>Test suite containing system tests for Optaweb applications in cloud.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-persistence-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.cloud</groupId>
+      <artifactId>framework-cloud-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.cloud</groupId>
+      <artifactId>framework-cloud-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.cloud</groupId>
+      <artifactId>test-cloud-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.optaweb.employeerostering</groupId>
+      <artifactId>employee-rostering-shared</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.optaweb.employeerostering</groupId>
+      <artifactId>employee-rostering-restclient</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/test-cloud/test-cloud-optaweb/src/main/java/org/kie/cloud/optaweb/rest/OptaWebObjectMapperResolver.java
+++ b/test-cloud/test-cloud-optaweb/src/main/java/org/kie/cloud/optaweb/rest/OptaWebObjectMapperResolver.java
@@ -1,4 +1,19 @@
-package org.kie.cloud.integrationtests.optaweb.rest;
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.cloud.optaweb.rest;
 
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;

--- a/test-cloud/test-cloud-optaweb/src/test/java/org/kie/cloud/optaweb/OptawebEmployeeRosteringIntegrationTest.java
+++ b/test-cloud/test-cloud-optaweb/src/test/java/org/kie/cloud/optaweb/OptawebEmployeeRosteringIntegrationTest.java
@@ -1,4 +1,19 @@
-package org.kie.cloud.integrationtests.optaweb;
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.cloud.optaweb;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -7,8 +22,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.scenario.EmployeeRosteringScenario;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
-import org.kie.cloud.integrationtests.testproviders.OptawebEmployeeRosteringTestProvider;
+import org.kie.cloud.optaweb.testprovider.OptawebEmployeeRosteringTestProvider;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 
 public class OptawebEmployeeRosteringIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<EmployeeRosteringScenario> {
 

--- a/test-cloud/test-cloud-optaweb/src/test/java/org/kie/cloud/optaweb/testprovider/OptawebEmployeeRosteringTestProvider.java
+++ b/test-cloud/test-cloud-optaweb/src/test/java/org/kie/cloud/optaweb/testprovider/OptawebEmployeeRosteringTestProvider.java
@@ -1,4 +1,19 @@
-package org.kie.cloud.integrationtests.testproviders;
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.cloud.optaweb.testprovider;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -11,7 +26,7 @@ import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.kie.cloud.integrationtests.optaweb.rest.OptaWebObjectMapperResolver;
+import org.kie.cloud.optaweb.rest.OptaWebObjectMapperResolver;
 import org.optaweb.employeerostering.restclient.ServiceClientFactory;
 import org.optaweb.employeerostering.shared.employee.Employee;
 import org.optaweb.employeerostering.shared.employee.EmployeeAvailabilityState;

--- a/test-cloud/test-cloud-optaweb/src/test/resources/logback.xml
+++ b/test-cloud/test-cloud-optaweb/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>[%d] %-5p- %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -61,32 +61,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.optaweb.employeerostering</groupId>
-      <artifactId>employee-rostering-shared</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.optaweb.employeerostering</groupId>
-      <artifactId>employee-rostering-restclient</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-persistence-jackson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -45,8 +45,6 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
-
-
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
@@ -57,6 +55,33 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.optaweb.employeerostering</groupId>
+      <artifactId>employee-rostering-shared</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.optaweb.employeerostering</groupId>
+      <artifactId>employee-rostering-restclient</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-persistence-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
   </dependencies>
 

--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -28,6 +28,11 @@
     </dependency>
     <dependency>
       <groupId>org.kie.cloud</groupId>
+      <artifactId>test-cloud-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.cloud</groupId>
       <artifactId>framework-cloud-common</artifactId>
       <scope>test</scope>
     </dependency>
@@ -130,62 +135,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>openshift</id>
-      <properties>
-        <skipTests>false</skipTests>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.kie.cloud</groupId>
-          <artifactId>framework-openshift</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.kie.cloud</groupId>
-          <artifactId>framework-openshift-templates</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>openshift-operator</id>
-      <properties>
-        <skipTests>false</skipTests>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.kie.cloud</groupId>
-          <artifactId>framework-openshift</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.kie.cloud</groupId>
-          <artifactId>framework-openshift-operator</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>parallel</id>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <parallel>suitesAndClasses</parallel>
-                <threadCountClasses>3</threadCountClasses>
-                <threadCountSuites>2</threadCountSuites>
-                <perCoreThreadCount>false</perCoreThreadCount>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.kie.cloud</groupId>
       <artifactId>framework-git</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.cloud</groupId>

--- a/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/integrationtests/optaweb/rest/OptaWebObjectMapperResolver.java
+++ b/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/integrationtests/optaweb/rest/OptaWebObjectMapperResolver.java
@@ -1,0 +1,32 @@
+package org.kie.cloud.integrationtests.optaweb.rest;
+
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.optaplanner.persistence.jackson.api.OptaPlannerJacksonModule;
+
+@Provider
+public class OptaWebObjectMapperResolver implements ContextResolver<ObjectMapper> {
+
+    private final ObjectMapper objectMapper;
+
+    public OptaWebObjectMapperResolver() {
+        objectMapper = new ObjectMapper()
+                .registerModule(OptaPlannerJacksonModule.createModule())
+                .registerModule(new JavaTimeModule())
+                // Write OffsetDateTime's (and similar) to JSON in ISO-8601 format,
+                // for example: 2007-12-03T10:15:30+01:00
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+    }
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return objectMapper;
+    }
+
+}

--- a/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/provider/git/Git.java
+++ b/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/provider/git/Git.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.cloud.provider.git;
+
+import org.kie.cloud.git.GitProvider;
+import org.kie.cloud.git.GitProviderService;
+
+public class Git {
+    private static final GitProvider gitProvider = new GitProviderService().createGitProvider();
+
+    public static GitProvider getProvider() {
+        return gitProvider;
+    }
+}

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractCloudIntegrationTest.java
@@ -55,5 +55,12 @@ public abstract class AbstractCloudIntegrationTest {
 
     protected static final DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactoryLoader.getInstance();
 
-    protected static final GitProvider gitProvider = new GitProviderService().createGitProvider();
+    private GitProvider gitProvider;
+
+    protected GitProvider getGitProvider() {
+        if (gitProvider == null) {
+            gitProvider = new GitProviderService().createGitProvider();
+        }
+        return gitProvider;
+    }
 }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractMethodIsolatedCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractMethodIsolatedCloudIntegrationTest.java
@@ -20,10 +20,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
-import org.kie.cloud.api.scenario.KieDeploymentScenario;
+import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.integrationtests.util.ScenarioDeployer;
 
-public abstract class AbstractMethodIsolatedCloudIntegrationTest<T extends KieDeploymentScenario> extends AbstractCloudIntegrationTest {
+public abstract class AbstractMethodIsolatedCloudIntegrationTest<T extends DeploymentScenario> extends AbstractCloudIntegrationTest {
 
     protected T deploymentScenario;
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractMethodIsolatedCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/AbstractMethodIsolatedCloudIntegrationTest.java
@@ -20,10 +20,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
-import org.kie.cloud.api.scenario.DeploymentScenario;
+import org.kie.cloud.api.scenario.KieDeploymentScenario;
 import org.kie.cloud.integrationtests.util.ScenarioDeployer;
 
-public abstract class AbstractMethodIsolatedCloudIntegrationTest<T extends DeploymentScenario> extends AbstractCloudIntegrationTest {
+public abstract class AbstractMethodIsolatedCloudIntegrationTest<T extends KieDeploymentScenario> extends AbstractCloudIntegrationTest {
 
     protected T deploymentScenario;
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/AbstractCloudArchitectureIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/AbstractCloudArchitectureIntegrationTest.java
@@ -28,7 +28,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.kie.cloud.api.deployment.Deployment;
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.scenario.GenericScenario;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.exception.KieServicesHttpException;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerResourceList;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/ManagedKieServersWithSmartRouterAndControllerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/ManagedKieServersWithSmartRouterAndControllerIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package org.kie.cloud.integrationtests.architecture;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,6 +50,8 @@ import org.kie.server.controller.client.KieServerControllerClient;
 import org.kie.server.integrationtests.router.client.KieServerRouterClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for Architecture 2 from
@@ -116,7 +116,7 @@ public class ManagedKieServersWithSmartRouterAndControllerIntegrationTest extend
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         controller = deploymentScenarioFactory.getWorkbenchSettingsBuilder()
                 .withApplicationName(CONTROLLER_NAME)
@@ -150,7 +150,7 @@ public class ManagedKieServersWithSmartRouterAndControllerIntegrationTest extend
                 .withSmartRouterConnection(RANDOM_URL_PREFIX + SMART_ROUTER_HOSTNAME, PORT)
                 .withControllerConnection(RANDOM_URL_PREFIX + CONTROLLER_HOSTNAME, PORT)
                 .withContainerDeployment(containerDeploymnet)
-                .withSourceLocation(gitProvider.getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
                 .build();
     }
 
@@ -183,7 +183,7 @@ public class ManagedKieServersWithSmartRouterAndControllerIntegrationTest extend
 
     @After
     public void deleteRepo() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/ManagedKieServersWithSmartRouterAndControllerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/ManagedKieServersWithSmartRouterAndControllerIntegrationTest.java
@@ -41,6 +41,7 @@ import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.SmartRouterAdminClientProvider;
 import org.kie.cloud.integrationtests.util.Constants;
+import org.kie.cloud.provider.git.Git;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.ProcessServicesClient;
@@ -116,7 +117,7 @@ public class ManagedKieServersWithSmartRouterAndControllerIntegrationTest extend
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         controller = deploymentScenarioFactory.getWorkbenchSettingsBuilder()
                 .withApplicationName(CONTROLLER_NAME)
@@ -150,7 +151,7 @@ public class ManagedKieServersWithSmartRouterAndControllerIntegrationTest extend
                 .withSmartRouterConnection(RANDOM_URL_PREFIX + SMART_ROUTER_HOSTNAME, PORT)
                 .withControllerConnection(RANDOM_URL_PREFIX + CONTROLLER_HOSTNAME, PORT)
                 .withContainerDeployment(containerDeploymnet)
-                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
                 .build();
     }
 
@@ -183,7 +184,7 @@ public class ManagedKieServersWithSmartRouterAndControllerIntegrationTest extend
 
     @After
     public void deleteRepo() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest.java
@@ -41,6 +41,7 @@ import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.SmartRouterAdminClientProvider;
 import org.kie.cloud.integrationtests.util.Constants;
+import org.kie.cloud.provider.git.Git;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.ProcessServicesClient;
@@ -103,7 +104,7 @@ public class UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest exte
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         controller = deploymentScenarioFactory.getWorkbenchSettingsBuilder()
                 .withApplicationName(CONTROLLER_NAME)
@@ -136,7 +137,7 @@ public class UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest exte
                 .withControllerUser(DeploymentConstants.getControllerUser(), DeploymentConstants.getControllerPassword())
                 .withSmartRouterConnection(RANDOM_URL_PREFIX + SMART_ROUTER_HOSTNAME, PORT)
                 .withContainerDeployment(containerDeploymnet)
-                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
                 .build();
     }
 
@@ -157,7 +158,7 @@ public class UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest exte
 
     @After
     public void deleteRepo() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest.java
@@ -23,8 +23,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -52,6 +50,8 @@ import org.kie.server.controller.client.KieServerControllerClient;
 import org.kie.server.integrationtests.router.client.KieServerRouterClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for Architecture 1 from
@@ -103,7 +103,7 @@ public class UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest exte
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         controller = deploymentScenarioFactory.getWorkbenchSettingsBuilder()
                 .withApplicationName(CONTROLLER_NAME)
@@ -136,7 +136,7 @@ public class UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest exte
                 .withControllerUser(DeploymentConstants.getControllerUser(), DeploymentConstants.getControllerPassword())
                 .withSmartRouterConnection(RANDOM_URL_PREFIX + SMART_ROUTER_HOSTNAME, PORT)
                 .withContainerDeployment(containerDeploymnet)
-                .withSourceLocation(gitProvider.getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
                 .build();
     }
 
@@ -157,7 +157,7 @@ public class UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest exte
 
     @After
     public void deleteRepo() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterIntegrationTest.java
@@ -23,8 +23,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -50,6 +48,8 @@ import org.kie.server.client.UserTaskServicesClient;
 import org.kie.server.integrationtests.router.client.KieServerRouterClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for Architecture 4 from
@@ -100,7 +100,7 @@ public class UnmanagedKieServersWithSmartRouterIntegrationTest extends AbstractC
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         smartRouter = deploymentScenarioFactory.getSmartRouterSettingsBuilder()
                 .withApplicationName(SMART_ROUTER_NAME)
@@ -126,7 +126,7 @@ public class UnmanagedKieServersWithSmartRouterIntegrationTest extends AbstractC
                 .withControllerUser(DeploymentConstants.getControllerUser(), DeploymentConstants.getControllerPassword())
                 .withSmartRouterConnection(RANDOM_URL_PREFIX + SMART_ROUTER_HOSTNAME, PORT)
                 .withContainerDeployment(containerDeploymnet)
-                .withSourceLocation(gitProvider.getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
                 .build();
     }
 
@@ -146,7 +146,7 @@ public class UnmanagedKieServersWithSmartRouterIntegrationTest extends AbstractC
 
     @After
     public void deleteRepo() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterIntegrationTest.java
@@ -40,6 +40,7 @@ import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.SmartRouterAdminClientProvider;
 import org.kie.cloud.integrationtests.util.Constants;
+import org.kie.cloud.provider.git.Git;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.ProcessServicesClient;
@@ -100,7 +101,7 @@ public class UnmanagedKieServersWithSmartRouterIntegrationTest extends AbstractC
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         smartRouter = deploymentScenarioFactory.getSmartRouterSettingsBuilder()
                 .withApplicationName(SMART_ROUTER_NAME)
@@ -126,7 +127,7 @@ public class UnmanagedKieServersWithSmartRouterIntegrationTest extends AbstractC
                 .withControllerUser(DeploymentConstants.getControllerUser(), DeploymentConstants.getControllerPassword())
                 .withSmartRouterConnection(RANDOM_URL_PREFIX + SMART_ROUTER_HOSTNAME, PORT)
                 .withContainerDeployment(containerDeploymnet)
-                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
                 .build();
     }
 
@@ -146,7 +147,7 @@ public class UnmanagedKieServersWithSmartRouterIntegrationTest extends AbstractC
 
     @After
     public void deleteRepo() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/drools/DroolsSessionFailoverIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/drools/DroolsSessionFailoverIntegrationTest.java
@@ -34,7 +34,7 @@ import org.kie.cloud.api.deployment.Instance;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;
 import org.kie.cloud.maven.MavenDeployer;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
@@ -27,11 +27,12 @@ import org.kie.cloud.api.deployment.Instance;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
-import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.util.Constants;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;
+import org.kie.cloud.provider.git.Git;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.exception.KieServicesHttpException;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieServerInfo;
@@ -68,9 +69,9 @@ public class ProcessFailoverIntegrationTest extends AbstractMethodIsolatedCloudI
 
     @Before
     public void setUp() {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
-        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
 
         kieServerControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchDeployment());
 
@@ -81,7 +82,7 @@ public class ProcessFailoverIntegrationTest extends AbstractMethodIsolatedCloudI
 
     @After
     public void tearDown() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
@@ -27,7 +27,7 @@ import org.kie.cloud.api.deployment.Instance;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.util.Constants;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package org.kie.cloud.integrationtests.jbpm;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
 import java.util.Map;
 
@@ -45,6 +43,8 @@ import org.kie.server.controller.client.KieServerControllerClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Category(JBPMOnly.class)
 public class ProcessFailoverIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<WorkbenchKieServerPersistentScenario> {
 
@@ -68,9 +68,9 @@ public class ProcessFailoverIntegrationTest extends AbstractMethodIsolatedCloudI
 
     @Before
     public void setUp() {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
-        WorkbenchUtils.deployProjectToWorkbench(gitProvider.getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
 
         kieServerControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchDeployment());
 
@@ -81,7 +81,7 @@ public class ProcessFailoverIntegrationTest extends AbstractMethodIsolatedCloudI
 
     @After
     public void tearDown() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/TimerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/TimerIntegrationTest.java
@@ -28,7 +28,7 @@ import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.util.Constants;
 import org.kie.cloud.integrationtests.util.TimeUtils;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
@@ -22,14 +22,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
 import org.kie.cloud.api.settings.LdapSettings;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProjectBuilderTestProvider;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.util.LdapSettingsConstants;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 public class ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest extends AbstractCloudIntegrationTest {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioLdapIntegrationTest.java
@@ -23,7 +23,7 @@ import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario;
 import org.kie.cloud.api.settings.LdapSettings;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
@@ -31,7 +31,7 @@ import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.integrationtests.util.LdapSettingsConstants;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioLdapIntegrationTest extends AbstractCloudIntegrationTest {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithMySqlLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithMySqlLdapIntegrationTest.java
@@ -21,14 +21,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
 import org.kie.cloud.api.settings.LdapSettings;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.integrationtests.util.LdapSettingsConstants;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 public class KieServerWithMySqlLdapIntegrationTest extends AbstractCloudIntegrationTest {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithPostgreSqlLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithPostgreSqlLdapIntegrationTest.java
@@ -21,14 +21,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
 import org.kie.cloud.api.settings.LdapSettings;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.integrationtests.util.LdapSettingsConstants;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 public class KieServerWithPostgreSqlLdapIntegrationTest extends AbstractCloudIntegrationTest {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
@@ -24,7 +24,7 @@ import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.api.settings.LdapSettings;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
@@ -35,7 +35,7 @@ import org.kie.cloud.integrationtests.testproviders.PersistenceTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProjectBuilderTestProvider;
 import org.kie.cloud.integrationtests.util.LdapSettingsConstants;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category(Baseline.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
@@ -42,10 +42,11 @@ import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.util.LdapSettingsConstants;
 import org.kie.cloud.maven.MavenDeployer;
+import org.kie.cloud.provider.git.Git;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
@@ -101,8 +102,8 @@ public class KieServerS2iWithLdapDroolsIntegrationTest
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository",
-                ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository",
+                                                                         ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         LdapSettings ldapSettings = deploymentScenarioFactory.getLdapSettingsBuilder()
                 .withLdapBindDn(LdapSettingsConstants.BIND_DN)
@@ -119,7 +120,7 @@ public class KieServerS2iWithLdapDroolsIntegrationTest
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
+                .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
                 .withDroolsServerFilterClasses(false).build();
 
         return deploymentScenarioFactory.getGenericScenarioBuilder().withLdapSettings(ldapSettings)
@@ -144,7 +145,7 @@ public class KieServerS2iWithLdapDroolsIntegrationTest
 
     @After
     public void deleteRepo() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package org.kie.cloud.integrationtests.ldap.s2i;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,6 +52,8 @@ import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.RuleServicesClient;
 import org.kie.server.integrationtests.shared.KieServerReflections;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class KieServerS2iWithLdapDroolsIntegrationTest
@@ -101,7 +101,7 @@ public class KieServerS2iWithLdapDroolsIntegrationTest
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix("KieServerS2iDroolsRepository",
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository",
                 ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         LdapSettings ldapSettings = deploymentScenarioFactory.getLdapSettingsBuilder()
@@ -119,7 +119,7 @@ public class KieServerS2iWithLdapDroolsIntegrationTest
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(gitProvider.getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
+                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
                 .withDroolsServerFilterClasses(false).build();
 
         return deploymentScenarioFactory.getGenericScenarioBuilder().withLdapSettings(ldapSettings)
@@ -144,7 +144,7 @@ public class KieServerS2iWithLdapDroolsIntegrationTest
 
     @After
     public void deleteRepo() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
@@ -42,7 +42,7 @@ import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.util.LdapSettingsConstants;
 import org.kie.cloud.maven.MavenDeployer;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/optaweb/OptawebEmployeeRosteringIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/optaweb/OptawebEmployeeRosteringIntegrationTest.java
@@ -1,0 +1,42 @@
+package org.kie.cloud.integrationtests.optaweb;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
+import org.kie.cloud.api.scenario.EmployeeRosteringScenario;
+import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.integrationtests.testproviders.OptawebEmployeeRosteringTestProvider;
+
+public class OptawebEmployeeRosteringIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<EmployeeRosteringScenario> {
+
+    private OptawebEmployeeRosteringTestProvider testProvider;
+
+    @Override
+    protected EmployeeRosteringScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
+        return deploymentScenarioFactory.getEmployeeRosteringScenarioBuilder().build();
+    }
+
+    @Before
+    public void setup() {
+        testProvider = new OptawebEmployeeRosteringTestProvider(getSanitizedUrl());
+    }
+
+    @Test
+    public void fromSkillToRoster() {
+        testProvider.fromSkillToRoster();
+    }
+
+    private URL getSanitizedUrl() {
+        URL appUrl = deploymentScenario.getEmployeeRosteringDeployment().getUrl();
+        String appUrlString = appUrl.toExternalForm();
+        String sanitizedAppUrl = appUrlString.endsWith("/") ? appUrlString : appUrlString + "/";
+        try {
+            return new URL(sanitizedAppUrl);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid Optaweb Employee Rostering application URL.", e);
+        }
+    }
+}

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchGitHooksPersistenceIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchGitHooksPersistenceIntegrationTest.java
@@ -43,7 +43,7 @@ import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentS
 import org.kie.cloud.api.scenario.KieDeploymentScenario;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.wb.test.rest.client.WorkbenchClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchGitHooksPersistenceIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchGitHooksPersistenceIntegrationTest.java
@@ -40,7 +40,7 @@ import org.kie.cloud.api.deployment.Deployment;
 import org.kie.cloud.api.deployment.Instance;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
-import org.kie.cloud.api.scenario.DeploymentScenario;
+import org.kie.cloud.api.scenario.KieDeploymentScenario;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
 import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
@@ -49,7 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @RunWith(Parameterized.class)
-public class WorkbenchGitHooksPersistenceIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<DeploymentScenario> {
+public class WorkbenchGitHooksPersistenceIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario> {
 
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchGitHooksPersistenceIntegrationTest.class);
 
@@ -57,7 +57,7 @@ public class WorkbenchGitHooksPersistenceIntegrationTest extends AbstractMethodI
     public String testScenarioName;
 
     @Parameterized.Parameter(value = 1)
-    public DeploymentScenario workbenchKieServerScenario;
+    public KieDeploymentScenario workbenchKieServerScenario;
 
     private WorkbenchClient workbenchClient;
 
@@ -83,7 +83,7 @@ public class WorkbenchGitHooksPersistenceIntegrationTest extends AbstractMethodI
     }
 
     @Override
-    protected DeploymentScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
+    protected KieDeploymentScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
         return workbenchKieServerScenario;
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
@@ -37,7 +37,7 @@ import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;
 import org.kie.server.api.model.KieContainerResourceList;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
@@ -14,8 +14,6 @@
  */
 package org.kie.cloud.integrationtests.persistence;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -52,6 +50,8 @@ import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.server.controller.api.model.spec.ServerTemplateList;
 import org.kie.server.controller.client.KieServerControllerClient;
 import org.kie.wb.test.rest.client.WorkbenchClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 @Ignore("Ignored as the tests are affected by RHPAM-1354. Unignore when the JIRA will be fixed.")
@@ -103,16 +103,16 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
     @After
     public void tearDown() {
         if (repositoryName != null) {
-            gitProvider.deleteGitRepository(repositoryName);
+            getGitProvider().deleteGitRepository(repositoryName);
             repositoryName = null;
         }
     }
 
     @Test
     public void testWorkbenchControllerPersistence() {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
-        WorkbenchUtils.deployProjectToWorkbench(gitProvider.getRepositoryUrl(repositoryName), workbenchDeployment, DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), workbenchDeployment, DEFINITION_PROJECT_NAME);
 
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
         String kieServerLocation = serverInfo.getLocation();

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
@@ -37,9 +37,10 @@ import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
-import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;
+import org.kie.cloud.provider.git.Git;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieServerInfo;
@@ -103,16 +104,16 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
     @After
     public void tearDown() {
         if (repositoryName != null) {
-            getGitProvider().deleteGitRepository(repositoryName);
+            Git.getProvider().deleteGitRepository(repositoryName);
             repositoryName = null;
         }
     }
 
     @Test
     public void testWorkbenchControllerPersistence() {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
-        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), workbenchDeployment, DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), workbenchDeployment, DEFINITION_PROJECT_NAME);
 
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
         String kieServerLocation = serverInfo.getLocation();

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
@@ -34,7 +34,7 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.deployment.Deployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
-import org.kie.cloud.api.scenario.DeploymentScenario;
+import org.kie.cloud.api.scenario.KieDeploymentScenario;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
@@ -55,13 +55,13 @@ import org.kie.wb.test.rest.client.WorkbenchClient;
 
 @RunWith(Parameterized.class)
 @Ignore("Ignored as the tests are affected by RHPAM-1354. Unignore when the JIRA will be fixed.")
-public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<DeploymentScenario> {
+public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario> {
 
     @Parameter(value = 0)
     public String testScenarioName;
 
     @Parameter(value = 1)
-    public DeploymentScenario workbenchKieServerScenario;
+    public KieDeploymentScenario workbenchKieServerScenario;
 
     private String repositoryName;
 
@@ -88,7 +88,7 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
     }
 
     @Override
-    protected DeploymentScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
+    protected KieDeploymentScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
         return workbenchKieServerScenario;
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/LivenessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/LivenessProbeIntegrationTest.java
@@ -33,7 +33,7 @@ import org.kie.cloud.api.deployment.Instance;
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.integrationtests.util.TimeUtils;
 import org.kie.cloud.maven.constants.MavenConstants;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
@@ -45,7 +45,7 @@ import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
@@ -114,7 +114,7 @@ public class ReadinessProbeIntegrationTest extends AbstractMethodIsolatedCloudIn
         }
 
         if (repositoryName != null) {
-            gitProvider.deleteGitRepository(repositoryName);
+            getGitProvider().deleteGitRepository(repositoryName);
             repositoryName = null;
         }
     }
@@ -146,9 +146,9 @@ public class ReadinessProbeIntegrationTest extends AbstractMethodIsolatedCloudIn
 
     @Test
     public void testKieServerReadinessProbe() {
-        String repositoryName = gitProvider.createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        String repositoryName = getGitProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
-        WorkbenchUtils.deployProjectToWorkbench(gitProvider.getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
 
         KieServerInfo serverInfo = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment()).getServerInfo().getResult();
         KieServerControllerClient kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchDeployment());

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
@@ -45,11 +45,12 @@ import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
-import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;
 import org.kie.cloud.maven.constants.MavenConstants;
+import org.kie.cloud.provider.git.Git;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.marshalling.Marshaller;
 import org.kie.server.api.marshalling.MarshallerFactory;
 import org.kie.server.api.marshalling.MarshallingFormat;
@@ -114,7 +115,7 @@ public class ReadinessProbeIntegrationTest extends AbstractMethodIsolatedCloudIn
         }
 
         if (repositoryName != null) {
-            getGitProvider().deleteGitRepository(repositoryName);
+            Git.getProvider().deleteGitRepository(repositoryName);
             repositoryName = null;
         }
     }
@@ -146,9 +147,9 @@ public class ReadinessProbeIntegrationTest extends AbstractMethodIsolatedCloudIn
 
     @Test
     public void testKieServerReadinessProbe() {
-        String repositoryName = getGitProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        String repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
-        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
 
         KieServerInfo serverInfo = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment()).getServerInfo().getResult();
         KieServerControllerClient kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchDeployment());

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
@@ -100,11 +100,11 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(gitProvider.getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
+                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
                 .withDroolsServerFilterClasses(false)
                 .build();
 
@@ -129,7 +129,7 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
 
     @After
     public void deleteRepo() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
@@ -45,6 +45,7 @@ import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.maven.MavenDeployer;
+import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
@@ -100,11 +101,11 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
+                .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
                 .withDroolsServerFilterClasses(false)
                 .build();
 
@@ -129,7 +130,7 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
 
     @After
     public void deleteRepo() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package org.kie.cloud.integrationtests.s2i;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,16 +42,18 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.maven.MavenDeployer;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.RuleServicesClient;
 import org.kie.server.integrationtests.shared.KieServerReflections;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 @Category(Baseline.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iHierarchicalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iHierarchicalIntegrationTest.java
@@ -17,8 +17,6 @@ package org.kie.cloud.integrationtests.s2i;
 
 import java.util.Arrays;
 import java.util.Collection;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
 
 import org.assertj.core.api.SoftAssertions;
@@ -47,6 +45,8 @@ import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.UserTaskServicesClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class KieServerS2iHierarchicalIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<GenericScenario> {
@@ -86,11 +86,11 @@ public class KieServerS2iHierarchicalIntegrationTest extends AbstractMethodIsola
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix(GIT_REPOSITORY_PREFIX, ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix(GIT_REPOSITORY_PREFIX, ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(gitProvider.getRepositoryUrl(repositoryName), REPO_BRANCH, GIT_CONTEXT_DIR, BUILT_KJAR_FOLDER)
+                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, GIT_CONTEXT_DIR, BUILT_KJAR_FOLDER)
                 .build();
 
         return deploymentScenarioFactory.getGenericScenarioBuilder()
@@ -107,7 +107,7 @@ public class KieServerS2iHierarchicalIntegrationTest extends AbstractMethodIsola
 
     @After
     public void deleteRepo() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iHierarchicalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iHierarchicalIntegrationTest.java
@@ -34,7 +34,7 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.util.Constants;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iHierarchicalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iHierarchicalIntegrationTest.java
@@ -34,10 +34,11 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.util.Constants;
+import org.kie.cloud.provider.git.Git;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.ProcessInstance;
@@ -86,11 +87,11 @@ public class KieServerS2iHierarchicalIntegrationTest extends AbstractMethodIsola
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix(GIT_REPOSITORY_PREFIX, ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(GIT_REPOSITORY_PREFIX, ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, GIT_CONTEXT_DIR, BUILT_KJAR_FOLDER)
+                .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, GIT_CONTEXT_DIR, BUILT_KJAR_FOLDER)
                 .build();
 
         return deploymentScenarioFactory.getGenericScenarioBuilder()
@@ -107,7 +108,7 @@ public class KieServerS2iHierarchicalIntegrationTest extends AbstractMethodIsola
 
     @After
     public void deleteRepo() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
@@ -17,8 +17,6 @@ package org.kie.cloud.integrationtests.s2i;
 
 import java.util.Arrays;
 import java.util.Collection;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
 
 import org.junit.After;
@@ -46,6 +44,8 @@ import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.UserTaskServicesClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class KieServerS2iJbpmIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<GenericScenario> {
@@ -80,11 +80,11 @@ public class KieServerS2iJbpmIntegrationTest extends AbstractMethodIsolatedCloud
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix("KieServerS2iJbpmRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iJbpmRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(gitProvider.getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
                 .build();
 
         return deploymentScenarioFactory.getGenericScenarioBuilder()
@@ -101,7 +101,7 @@ public class KieServerS2iJbpmIntegrationTest extends AbstractMethodIsolatedCloud
 
     @After
     public void deleteRepo() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
@@ -33,10 +33,11 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.util.Constants;
+import org.kie.cloud.provider.git.Git;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.ProcessInstance;
@@ -80,11 +81,11 @@ public class KieServerS2iJbpmIntegrationTest extends AbstractMethodIsolatedCloud
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iJbpmRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iJbpmRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
                 .build();
 
         return deploymentScenarioFactory.getGenericScenarioBuilder()
@@ -101,7 +102,7 @@ public class KieServerS2iJbpmIntegrationTest extends AbstractMethodIsolatedCloud
 
     @After
     public void deleteRepo() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
@@ -33,7 +33,7 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.util.Constants;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package org.kie.cloud.integrationtests.s2i;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -40,13 +38,16 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.maven.MavenDeployer;
+import org.kie.cloud.provider.git.Git;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.SolverInstance;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.SolverServicesClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<GenericScenario> {
@@ -93,11 +94,11 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iOptaplannerRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iOptaplannerRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
+                .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
                 .build();
 
         return deploymentScenarioFactory.getGenericScenarioBuilder()
@@ -123,7 +124,7 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
 
     @After
     public void deleteRepo() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
@@ -93,11 +93,11 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix("KieServerS2iOptaplannerRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iOptaplannerRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(gitProvider.getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
+                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
                 .build();
 
         return deploymentScenarioFactory.getGenericScenarioBuilder()
@@ -123,7 +123,7 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
 
     @After
     public void deleteRepo() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
@@ -40,7 +40,7 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.maven.MavenDeployer;
 import org.kie.server.api.model.ReleaseId;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerHttpScalingIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerHttpScalingIntegrationTest.java
@@ -30,7 +30,7 @@ import org.junit.runners.Parameterized;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
-import org.kie.cloud.api.scenario.DeploymentScenario;
+import org.kie.cloud.api.scenario.KieDeploymentScenario;
 import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
@@ -54,13 +54,13 @@ import org.kie.server.controller.client.KieServerControllerClient;
 
 @RunWith(Parameterized.class)
 @Ignore("Currently all templates are using WebSockets, generic scenario builder is not capable of configuring HTTP. Ignoring for now until new generic scenario builder is available.")
-public class KieServerHttpScalingIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<DeploymentScenario> {
+public class KieServerHttpScalingIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario> {
 
     @Parameterized.Parameter(value = 0)
     public String testScenarioName;
 
     @Parameterized.Parameter(value = 1)
-    public DeploymentScenario deploymentScenario;
+    public KieDeploymentScenario deploymentScenario;
 
     private KieServerControllerClient kieControllerClient;
     private KieServicesClient kieServerClient;
@@ -95,7 +95,7 @@ public class KieServerHttpScalingIntegrationTest extends AbstractMethodIsolatedC
     }
 
     @Override
-    protected DeploymentScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
+    protected KieDeploymentScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
         return deploymentScenario;
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerHttpScalingIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerHttpScalingIntegrationTest.java
@@ -36,7 +36,7 @@ import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;
 import org.kie.cloud.maven.MavenDeployer;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWithSmartRouterHttpScalingIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWithSmartRouterHttpScalingIntegrationTest.java
@@ -26,7 +26,7 @@ import org.kie.cloud.api.scenario.ClusteredWorkbenchRuntimeSmartRouterTwoKieServ
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.SmartRouterAdminClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.util.SmartRouterUtils;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
@@ -20,7 +20,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
@@ -28,7 +28,7 @@ import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category(Smoke.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest.java
@@ -20,7 +20,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerPersistentScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
@@ -28,7 +28,7 @@ import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category(Smoke.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioIntegrationTest.java
@@ -20,7 +20,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
@@ -29,7 +29,7 @@ import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.integrationtests.testproviders.SmartRouterTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category(Smoke.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ImageVersionIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ImageVersionIntegrationTest.java
@@ -29,7 +29,7 @@ import org.kie.cloud.api.deployment.Deployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.util.TimeUtils;
 import org.kie.server.client.KieServicesClient;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
@@ -36,7 +36,7 @@ import org.kie.api.command.KieCommands;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
-import org.kie.cloud.api.scenario.DeploymentScenario;
+import org.kie.cloud.api.scenario.KieDeploymentScenario;
 import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
@@ -55,13 +55,13 @@ import org.kie.server.integrationtests.shared.KieServerAssert;
 
 @Category(Smoke.class)
 @RunWith(Parameterized.class)
-public class KieServerWithBuiltKjarIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<DeploymentScenario> {
+public class KieServerWithBuiltKjarIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario> {
 
     @Parameter(value = 0)
     public String testScenarioName;
 
     @Parameter(value = 1)
-    public DeploymentScenario kieServerScenario;
+    public KieDeploymentScenario kieServerScenario;
 
     private static final String LIST_NAME = "list";
     private static final String LIST_OUTPUT_NAME = "output-list";
@@ -108,7 +108,7 @@ public class KieServerWithBuiltKjarIntegrationTest extends AbstractMethodIsolate
     }
 
     @Override
-    protected DeploymentScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
+    protected KieDeploymentScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
         return kieServerScenario;
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
@@ -41,7 +41,7 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.maven.MavenDeployer;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithExternalDatabaseIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithExternalDatabaseIntegrationTest.java
@@ -21,14 +21,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 import static org.junit.Assume.assumeTrue;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithMySqlScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithMySqlScenarioIntegrationTest.java
@@ -20,14 +20,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category(Smoke.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithPostgreSqlScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithPostgreSqlScenarioIntegrationTest.java
@@ -20,14 +20,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category(Smoke.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
@@ -20,7 +20,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
@@ -28,7 +28,7 @@ import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category(Smoke.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerScenarioIntegrationTest.java
@@ -20,13 +20,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category(Smoke.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
@@ -24,13 +24,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProjectBuilderTestProvider;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 public class ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest extends AbstractCloudIntegrationTest {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioSsoIntegrationTest.java
@@ -25,14 +25,14 @@ import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioSsoIntegrationTest extends AbstractCloudIntegrationTest {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/KieServerWithMySqlSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/KieServerWithMySqlSsoIntegrationTest.java
@@ -23,13 +23,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 public class KieServerWithMySqlSsoIntegrationTest extends AbstractCloudIntegrationTest {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/KieServerWithPostgreSqlSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/KieServerWithPostgreSqlSsoIntegrationTest.java
@@ -23,13 +23,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 public class KieServerWithPostgreSqlSsoIntegrationTest extends AbstractCloudIntegrationTest {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/WorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/WorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
@@ -26,8 +26,8 @@ import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
-import org.kie.cloud.integrationtests.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.Baseline;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
@@ -36,7 +36,7 @@ import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.PersistenceTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProjectBuilderTestProvider;
-import org.kie.cloud.integrationtests.util.ScenarioDeployer;
+import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category(Baseline.class)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
@@ -43,9 +43,10 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.maven.MavenDeployer;
+import org.kie.cloud.provider.git.Git;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
@@ -104,11 +105,11 @@ public class KieServerS2iWithSsoDroolsIntegrationTest extends AbstractMethodIsol
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
+                .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
                 .withDroolsServerFilterClasses(false)
                 .withHostame(RANDOM_URL_PREFIX + KIE_SERVER_HOSTNAME)
                 .withSecuredHostame(SECURED_URL_PREFIX + RANDOM_URL_PREFIX + KIE_SERVER_HOSTNAME)
@@ -136,7 +137,7 @@ public class KieServerS2iWithSsoDroolsIntegrationTest extends AbstractMethodIsol
 
     @After
     public void deleteRepo() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
@@ -43,7 +43,7 @@ import org.kie.cloud.api.scenario.GenericScenario;
 import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.api.settings.builder.KieServerS2ISettingsBuilder;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.maven.MavenDeployer;
 import org.kie.server.api.model.KieContainerResource;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package org.kie.cloud.integrationtests.sso.s2i;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,6 +52,8 @@ import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.RuleServicesClient;
 import org.kie.server.integrationtests.shared.KieServerReflections;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class KieServerS2iWithSsoDroolsIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<GenericScenario> {
@@ -104,11 +104,11 @@ public class KieServerS2iWithSsoDroolsIntegrationTest extends AbstractMethodIsol
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                .withSourceLocation(gitProvider.getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
+                .withSourceLocation(getGitProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEPLOYED_KJAR.getName())
                 .withDroolsServerFilterClasses(false)
                 .withHostame(RANDOM_URL_PREFIX + KIE_SERVER_HOSTNAME)
                 .withSecuredHostame(SECURED_URL_PREFIX + RANDOM_URL_PREFIX + KIE_SERVER_HOSTNAME)
@@ -136,7 +136,7 @@ public class KieServerS2iWithSsoDroolsIntegrationTest extends AbstractMethodIsol
 
     @After
     public void deleteRepo() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/DbSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/DbSurvivalIntegrationTest.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,7 +36,7 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.integrationtests.util.Constants;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.maven.MavenDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 import org.kie.server.api.exception.KieServicesException;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
@@ -19,8 +19,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.assertj.core.api.SoftAssertions;
 import org.junit.After;
 import org.junit.Before;
@@ -36,13 +34,13 @@ import org.kie.cloud.api.settings.DeploymentSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.SmartRouterAdminClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.util.Constants;
 import org.kie.cloud.integrationtests.util.SmartRouterUtils;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;
 import org.kie.cloud.maven.constants.MavenConstants;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
@@ -57,6 +55,8 @@ import org.kie.server.controller.client.KieServerControllerClient;
 import org.kie.server.integrationtests.router.client.KieServerRouterClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(JBPMOnly.class)
 public class KieServerWithSmartRouterAndControllerSurvivalIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<GenericScenario> {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
@@ -40,6 +40,7 @@ import org.kie.cloud.integrationtests.util.Constants;
 import org.kie.cloud.integrationtests.util.SmartRouterUtils;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;
 import org.kie.cloud.maven.constants.MavenConstants;
+import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerResourceList;
@@ -130,9 +131,9 @@ public class KieServerWithSmartRouterAndControllerSurvivalIntegrationTest extend
 
     @Before
     public void setUp() {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix(controllerDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(controllerDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
-        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), controllerDeployment(), DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), controllerDeployment(), DEFINITION_PROJECT_NAME);
 
         kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(controllerDeployment());
         kieServerClient = KieServerClientProvider.getKieServerClient(kieServerDeployment());
@@ -145,7 +146,7 @@ public class KieServerWithSmartRouterAndControllerSurvivalIntegrationTest extend
 
     @After
     public void tearDown() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
@@ -130,9 +130,9 @@ public class KieServerWithSmartRouterAndControllerSurvivalIntegrationTest extend
 
     @Before
     public void setUp() {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix(controllerDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix(controllerDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
-        WorkbenchUtils.deployProjectToWorkbench(gitProvider.getRepositoryUrl(repositoryName), controllerDeployment(), DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), controllerDeployment(), DEFINITION_PROJECT_NAME);
 
         kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(controllerDeployment());
         kieServerClient = KieServerClientProvider.getKieServerClient(kieServerDeployment());
@@ -145,7 +145,7 @@ public class KieServerWithSmartRouterAndControllerSurvivalIntegrationTest extend
 
     @After
     public void tearDown() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
@@ -73,9 +73,9 @@ public class KieServerWithWorkbenchSurvivalIntegrationTest extends AbstractMetho
 
     @Before
     public void setUp() {
-        repositoryName = gitProvider.createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile() + "/" + DEFINITION_PROJECT_NAME);
+        repositoryName = getGitProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile() + "/" + DEFINITION_PROJECT_NAME);
 
-        WorkbenchUtils.deployProjectToWorkbench(gitProvider.getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
 
         kieServerControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchDeployment());
 
@@ -86,7 +86,7 @@ public class KieServerWithWorkbenchSurvivalIntegrationTest extends AbstractMetho
 
     @After
     public void tearDown() {
-        gitProvider.deleteGitRepository(repositoryName);
+        getGitProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package org.kie.cloud.integrationtests.survival;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -35,12 +33,13 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
-import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.util.Constants;
 import org.kie.cloud.integrationtests.util.WorkbenchUtils;
+import org.kie.cloud.provider.git.Git;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.api.model.instance.ProcessInstance;
@@ -53,7 +52,13 @@ import org.kie.server.controller.client.KieServerControllerClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+<<<<<<< HEAD
 @Category({JBPMOnly.class, Baseline.class})
+=======
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(JBPMOnly.class)
+>>>>>>> Avoid GitProvider leaking to every test
 public class KieServerWithWorkbenchSurvivalIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<WorkbenchKieServerPersistentScenario> {
 
     private KieServerControllerClient kieServerControllerClient;
@@ -73,9 +78,9 @@ public class KieServerWithWorkbenchSurvivalIntegrationTest extends AbstractMetho
 
     @Before
     public void setUp() {
-        repositoryName = getGitProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile() + "/" + DEFINITION_PROJECT_NAME);
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile() + "/" + DEFINITION_PROJECT_NAME);
 
-        WorkbenchUtils.deployProjectToWorkbench(getGitProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
 
         kieServerControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchDeployment());
 
@@ -86,7 +91,7 @@ public class KieServerWithWorkbenchSurvivalIntegrationTest extends AbstractMetho
 
     @After
     public void tearDown() {
-        getGitProvider().deleteGitRepository(repositoryName);
+        Git.getProvider().deleteGitRepository(repositoryName);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
@@ -35,7 +35,7 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
-import org.kie.cloud.integrationtests.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.integrationtests.Kjar;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.integrationtests.category.JBPMOnly;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
@@ -52,13 +52,9 @@ import org.kie.server.controller.client.KieServerControllerClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-<<<<<<< HEAD
-@Category({JBPMOnly.class, Baseline.class})
-=======
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Category(JBPMOnly.class)
->>>>>>> Avoid GitProvider leaking to every test
+@Category({JBPMOnly.class, Baseline.class})
 public class KieServerWithWorkbenchSurvivalIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<WorkbenchKieServerPersistentScenario> {
 
     private KieServerControllerClient kieServerControllerClient;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/OptawebEmployeeRosteringTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/OptawebEmployeeRosteringTestProvider.java
@@ -1,0 +1,181 @@
+package org.kie.cloud.integrationtests.testproviders;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.kie.cloud.integrationtests.optaweb.rest.OptaWebObjectMapperResolver;
+import org.optaweb.employeerostering.restclient.ServiceClientFactory;
+import org.optaweb.employeerostering.shared.employee.Employee;
+import org.optaweb.employeerostering.shared.employee.EmployeeAvailabilityState;
+import org.optaweb.employeerostering.shared.employee.EmployeeRestService;
+import org.optaweb.employeerostering.shared.employee.view.EmployeeAvailabilityView;
+import org.optaweb.employeerostering.shared.roster.RosterRestService;
+import org.optaweb.employeerostering.shared.roster.RosterState;
+import org.optaweb.employeerostering.shared.roster.view.ShiftRosterView;
+import org.optaweb.employeerostering.shared.shift.ShiftRestService;
+import org.optaweb.employeerostering.shared.shift.view.ShiftView;
+import org.optaweb.employeerostering.shared.skill.Skill;
+import org.optaweb.employeerostering.shared.skill.SkillRestService;
+import org.optaweb.employeerostering.shared.spot.Spot;
+import org.optaweb.employeerostering.shared.spot.SpotRestService;
+import org.optaweb.employeerostering.shared.tenant.Tenant;
+import org.optaweb.employeerostering.shared.tenant.TenantRestService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OptawebEmployeeRosteringTestProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OptawebEmployeeRosteringTestProvider.class);
+
+    private static final int ROSTER_YEAR = 2019;
+    private static final int ROSTER_MONTH = 1;
+    private static final int ROSTER_START_DAY = 2;
+
+    private Integer tenantId;
+
+    private TenantRestService tenantRestService;
+    private SkillRestService skillRestService;
+    private EmployeeRestService employeeRestService;
+    private SpotRestService spotRestService;
+    private ShiftRestService shiftRestService;
+    private RosterRestService rosterRestService;
+
+    public OptawebEmployeeRosteringTestProvider(URL baseUrl) {
+        LOGGER.info("Connecting to " + baseUrl.toExternalForm());
+
+        ResteasyClient resteasyClient = new ResteasyClientBuilder().register(OptaWebObjectMapperResolver.class).build();
+        ServiceClientFactory serviceClientFactory = new ServiceClientFactory(baseUrl, resteasyClient);
+
+        tenantRestService = serviceClientFactory.createTenantRestServiceClient();
+        skillRestService = serviceClientFactory.createSkillRestServiceClient();
+        employeeRestService = serviceClientFactory.createEmployeeRestServiceClient();
+        spotRestService = serviceClientFactory.createSpotRestServiceClient();
+        shiftRestService = serviceClientFactory.createShiftRestServiceClient();
+        rosterRestService = serviceClientFactory.createRosterRestServiceClient();
+    }
+
+    public void fromSkillToRoster() {
+        createTenant();
+
+        Skill ambulatoryCare = newSkill("Ambulatory care");
+        Skill criticalCare = newSkill("Critical care");
+
+        Spot neurology = newSpot("Neurology", ambulatoryCare);
+        Spot emergency = newSpot("Emergency", criticalCare);
+
+        Employee francis = newEmployee("Francis Fitzgerald Groovy", ambulatoryCare, criticalCare);
+        Employee ivy = newEmployee("Ivy Green", ambulatoryCare);
+
+        employeeUnavailability(francis, ROSTER_START_DAY, 8, 16);
+
+        newShift(neurology, ROSTER_START_DAY, 10, 18);
+        newShift(emergency, ROSTER_START_DAY + 1, 8, 16);
+
+        rosterRestService.solveRoster(tenantId);
+        sleep(500);
+        rosterRestService.terminateRosterEarly(tenantId);
+
+        LocalDate startDate = LocalDate.of(ROSTER_YEAR, ROSTER_MONTH, ROSTER_START_DAY);
+        LocalDate endDate = startDate.plusDays(1);
+        ShiftRosterView shiftRosterView =
+                rosterRestService.getShiftRosterView(tenantId, 0, 10, startDate.toString(), endDate.toString());
+
+        Assertions.assertThat(shiftRosterView).isNotNull();
+        Assertions.assertThat(shiftRosterView.getEmployeeList()).containsExactlyInAnyOrder(francis, ivy);
+
+        Assertions.assertThat(shiftRosterView.getSpotList()).containsExactlyInAnyOrder(neurology, emergency);
+        Assertions.assertThat(shiftRosterView.getSpotIdToShiftViewListMap().get(neurology.getId()))
+                .isNotEmpty()
+                .extracting(ShiftView::getEmployeeId).containsOnly(ivy.getId());
+    }
+
+    private void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            LOGGER.warn("Interrupted sleep.", e);
+        }
+    }
+
+    private void createTenant() {
+        LocalDate firstDraft = LocalDate.of(ROSTER_YEAR, ROSTER_MONTH, ROSTER_START_DAY);
+        LocalDate historical = firstDraft.minusWeeks(1);
+        RosterState rosterState = new RosterState(null, 7, firstDraft, 7, 24, 0, 7, historical, ZoneOffset.UTC);
+        rosterState.setTenant(new Tenant("Test Tenant"));
+        Tenant tenant = tenantRestService.addTenant(rosterState);
+        if (tenant == null) {
+            throw new IllegalArgumentException("Cannot create tenant.");
+        }
+        tenantId = tenant.getId();
+    }
+
+    private void deleteTenant() {
+        if (tenantId != null) {
+            tenantRestService.removeTenant(tenantId);
+        }
+    }
+
+    private Skill newSkill(String skillName) {
+        return skillRestService.addSkill(tenantId, new Skill(tenantId, skillName));
+    }
+
+    private Spot newSpot(String spotName, Skill... requiredSkills) {
+        return spotRestService.addSpot(tenantId, new Spot(tenantId, spotName, newSkillSet(requiredSkills)));
+    }
+
+    private Employee newEmployee(String name, Skill... skills) {
+        Employee employee = new Employee(tenantId, name);
+        employee.setSkillProficiencySet(newSkillSet(skills));
+        return employeeRestService.addEmployee(tenantId, employee);
+    }
+
+    private Set<Skill> newSkillSet(Skill... skills) {
+        Set<Skill> skillSet = new HashSet<>();
+        for (Skill skill : skills) {
+            skillSet.add(skill);
+        }
+
+        return skillSet;
+    }
+
+    private ShiftView newShift(Spot spot, int day, int startHour, int endHour) {
+        ShiftView shiftView = new ShiftView(tenantId, spot, newDateTime(day, startHour), newDateTime(day, endHour));
+        return shiftRestService.addShift(tenantId, shiftView);
+    }
+
+    private EmployeeAvailabilityView employeeUnavailability(Employee employee, int day, int startHour, int endHour) {
+        EmployeeAvailabilityView employeeAvailability = new EmployeeAvailabilityView(
+                tenantId,
+                employee,
+                newDateTime(day, startHour),
+                newDateTime(day, endHour),
+                EmployeeAvailabilityState.UNAVAILABLE
+        );
+        return employeeRestService.addEmployeeAvailability(tenantId, employeeAvailability);
+    }
+
+    private LocalDateTime newDateTime(int dayOfMonth, int hour) {
+        return LocalDateTime.of(ROSTER_YEAR, ROSTER_MONTH, dayOfMonth, hour, 0);
+    }
+
+    /**
+     * For debugging purpose - replace the URL according to your deployment.
+     */
+    public static void main(String[] args) throws MalformedURLException {
+        String url = "http://localhost:8080/";
+        URL appUrl = new URL(url);
+        OptawebEmployeeRosteringTestProvider testProvider = new OptawebEmployeeRosteringTestProvider(appUrl);
+        try {
+            testProvider.fromSkillToRoster();
+        } finally {
+            testProvider.deleteTenant();
+        }
+    }
+}


### PR DESCRIPTION
Consists of PRs:
https://github.com/kiegroup/kie-cloud-tests/pull/283
https://github.com/jboss-integration/bxms-qe-tests/pull/2220

- splits the test-cloud-remote module into sub-modules
- generalizes hierarchy of deployments
- removes GitProvider from tests that do not use it
- introduces integration test for the Optaweb Employee Rostering app

@Christopher-Chianelli @ge0ffrey just FYI if you are interested in the test automation for OpenShift templates