### PR TITLE
Exclude integration tests from surefire run

### DIFF
--- a/test-cloud/test-cloud-optaweb/pom.xml
+++ b/test-cloud/test-cloud-optaweb/pom.xml
@@ -82,6 +82,22 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <groupId>org.apache.maven.plugins</groupId>
+          <configuration>
+            <excludes>
+              <exclude>**/*IntegrationTest.java</exclude>
+            </excludes>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <profiles>
     <profile>
       <id>openshift</id>


### PR DESCRIPTION
To avoid running tests twice