### PR TITLE
Replace ClassLoader with specific class for loading resources

### DIFF
--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/EmptyManagedKieServersWithSmartRouterAndControllerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/EmptyManagedKieServersWithSmartRouterAndControllerIntegrationTest.java
@@ -146,7 +146,7 @@ public class EmptyManagedKieServersWithSmartRouterAndControllerIntegrationTest e
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(EmptyManagedKieServersWithSmartRouterAndControllerIntegrationTest.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/ManagedKieServersWithSmartRouterAndControllerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/ManagedKieServersWithSmartRouterAndControllerIntegrationTest.java
@@ -120,7 +120,7 @@ public class ManagedKieServersWithSmartRouterAndControllerIntegrationTest extend
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("architectureRepository", ManagedKieServersWithSmartRouterAndControllerIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         controller = deploymentScenarioFactory.getWorkbenchSettingsBuilder()
                 .withApplicationName(CONTROLLER_NAME)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest.java
@@ -109,7 +109,7 @@ public class UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest exte
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("architectureRepository", UnmanagedKieServersWithSmartRouterAndControllerIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         controller = deploymentScenarioFactory.getWorkbenchSettingsBuilder()
                 .withApplicationName(CONTROLLER_NAME)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/architecture/UnmanagedKieServersWithSmartRouterIntegrationTest.java
@@ -106,7 +106,7 @@ public class UnmanagedKieServersWithSmartRouterIntegrationTest extends AbstractC
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("architectureRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("architectureRepository", UnmanagedKieServersWithSmartRouterIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         smartRouter = deploymentScenarioFactory.getSmartRouterSettingsBuilder()
                 .withApplicationName(SMART_ROUTER_NAME)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/drools/DroolsSessionFailoverIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/drools/DroolsSessionFailoverIntegrationTest.java
@@ -81,7 +81,7 @@ public class DroolsSessionFailoverIntegrationTest extends AbstractMethodIsolated
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/rule-project").getFile());
+        MavenDeployer.buildAndDeployMavenProject(DroolsSessionFailoverIntegrationTest.class.getResource("/kjars-sources/rule-project").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/ProcessFailoverIntegrationTest.java
@@ -69,7 +69,7 @@ public class ProcessFailoverIntegrationTest extends AbstractMethodIsolatedCloudI
 
     @Before
     public void setUp() {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ProcessFailoverIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
         WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/TimerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/TimerIntegrationTest.java
@@ -66,7 +66,7 @@ public class TimerIntegrationTest extends AbstractMethodIsolatedCloudIntegration
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEPLOYED_KJAR.getName()).getFile());
+        MavenDeployer.buildAndDeployMavenProject(TimerIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEPLOYED_KJAR.getName()).getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
@@ -112,7 +112,7 @@ public class KieServerS2iWithLdapDroolsIntegrationTest extends AbstractMethodIso
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
         repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository",
-                                                                         ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+                                                                         KieServerS2iWithLdapDroolsIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         LdapSettings ldapSettings = deploymentScenarioFactory.getLdapSettingsBuilder()
                 .withLdapBindDn(LdapSettingsConstants.BIND_DN)
@@ -139,7 +139,7 @@ public class KieServerS2iWithLdapDroolsIntegrationTest extends AbstractMethodIso
     @BeforeClass
     public static void buildKjar() {
         MavenDeployer.buildAndInstallMavenProject(
-                ClassLoader.class.getResource("/kjars-sources/stateless-session").getFile());
+                KieServerS2iWithLdapDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
@@ -124,7 +124,7 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
 
     @Test
     public void testWorkbenchControllerPersistence() {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), WorkbenchPersistenceIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
         WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), workbenchDeployment, DEFINITION_PROJECT_NAME);
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
@@ -162,7 +162,7 @@ public class ReadinessProbeIntegrationTest extends AbstractMethodIsolatedCloudIn
 
     @Test
     public void testKieServerReadinessProbe() {
-        String repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        String repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ReadinessProbeIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
         WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
@@ -109,7 +109,7 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", KieServerS2iDroolsIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
@@ -124,7 +124,7 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndInstallMavenProject(ClassLoader.class.getResource("/kjars-sources/stateless-session").getFile());
+        MavenDeployer.buildAndInstallMavenProject(KieServerS2iDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iHierarchicalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iHierarchicalIntegrationTest.java
@@ -95,7 +95,7 @@ public class KieServerS2iHierarchicalIntegrationTest extends AbstractMethodIsola
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(GIT_REPOSITORY_PREFIX, ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(GIT_REPOSITORY_PREFIX, KieServerS2iHierarchicalIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
@@ -89,7 +89,7 @@ public class KieServerS2iJbpmIntegrationTest extends AbstractMethodIsolatedCloud
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iJbpmRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iJbpmRepository", KieServerS2iJbpmIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
@@ -104,7 +104,7 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iOptaplannerRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iOptaplannerRepository", KieServerS2iOptaplannerIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
@@ -119,7 +119,7 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
     @BeforeClass
     public static void buildKjar() {
         MavenDeployer.buildAndInstallMavenProject(
-                ClassLoader.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile());
+                KieServerS2iOptaplannerIntegrationTest.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerHttpScalingIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerHttpScalingIntegrationTest.java
@@ -113,7 +113,7 @@ public class KieServerHttpScalingIntegrationTest extends AbstractMethodIsolatedC
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(KieServerHttpScalingIntegrationTest.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWebSocketScalingIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWebSocketScalingIntegrationTest.java
@@ -84,7 +84,7 @@ public class KieServerWebSocketScalingIntegrationTest {
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(KieServerWebSocketScalingIntegrationTest.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWithSmartRouterHttpScalingIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWithSmartRouterHttpScalingIntegrationTest.java
@@ -67,7 +67,7 @@ public class KieServerWithSmartRouterHttpScalingIntegrationTest extends Abstract
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(KieServerWithSmartRouterHttpScalingIntegrationTest.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
@@ -83,9 +83,9 @@ public class ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrat
     }
 
     static {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/hello-rules-snapshot").getFile());
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.class.getResource("/kjars-sources/hello-rules-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile());
     }
 
     @AfterClass

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
@@ -130,7 +130,7 @@ public class KieServerWithBuiltKjarIntegrationTest extends AbstractMethodIsolate
 
     @BeforeClass
     public static void deployMavenProject() {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/hello-rules-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(KieServerWithBuiltKjarIntegrationTest.class.getResource("/kjars-sources/hello-rules-snapshot").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
@@ -115,7 +115,7 @@ public class KieServerS2iWithSsoDroolsIntegrationTest extends AbstractMethodIsol
 
     @Override
     protected GenericScenario createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", KieServerS2iWithSsoDroolsIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
         DeploymentSettings kieServerS2Isettings = kieServerS2ISettingsBuilder
                 .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
@@ -133,7 +133,7 @@ public class KieServerS2iWithSsoDroolsIntegrationTest extends AbstractMethodIsol
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndInstallMavenProject(ClassLoader.class.getResource("/kjars-sources/stateless-session").getFile());
+        MavenDeployer.buildAndInstallMavenProject(KieServerS2iWithSsoDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/DbSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/DbSurvivalIntegrationTest.java
@@ -97,7 +97,7 @@ public class DbSurvivalIntegrationTest extends AbstractMethodIsolatedCloudIntegr
 
     @BeforeClass
     public static void deployMavenProject() {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(DbSurvivalIntegrationTest.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
@@ -132,7 +132,7 @@ public class KieServerWithSmartRouterAndControllerSurvivalIntegrationTest extend
 
     @Before
     public void setUp() {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(controllerDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(controllerDeployment().getNamespace(), KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
 
         WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), controllerDeployment(), DEFINITION_PROJECT_NAME);
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithWorkbenchSurvivalIntegrationTest.java
@@ -76,7 +76,7 @@ public class KieServerWithWorkbenchSurvivalIntegrationTest extends AbstractMetho
 
     @Before
     public void setUp() {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ClassLoader.class.getResource(PROJECT_SOURCE_FOLDER).getFile() + "/" + DEFINITION_PROJECT_NAME);
+        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), KieServerWithWorkbenchSurvivalIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile() + "/" + DEFINITION_PROJECT_NAME);
 
         WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/FireRulesTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/FireRulesTestProvider.java
@@ -56,7 +56,7 @@ public class FireRulesTestProvider {
     private static KieCommands commandsFactory = KieServices.Factory.get().getCommands();
 
     static {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/hello-rules-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(FireRulesTestProvider.class.getResource("/kjars-sources/hello-rules-snapshot").getFile());
     }
 
     public static void testDeployFromKieServerAndFireRules(KieServerDeployment kieServerDeployment) {
@@ -82,7 +82,7 @@ public class FireRulesTestProvider {
         KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(kieServerDeployment);
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
 
-        String repositoryName = gitProvider.createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), ClassLoader.class.getResource("/kjars-sources/hello-rules").getFile());
+        String repositoryName = gitProvider.createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), FireRulesTestProvider.class.getResource("/kjars-sources/hello-rules").getFile());
         try {
             WorkbenchUtils.deployProjectToWorkbench(gitProvider.getRepositoryUrl(repositoryName), workbenchDeployment, Kjar.HELLO_RULES.getName());
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/HttpsKieServerTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/HttpsKieServerTestProvider.java
@@ -56,7 +56,7 @@ public class HttpsKieServerTestProvider {
     private static final String KIE_CONTAINERS_REQUEST_URL = KIE_SERVER_INFO_REST_REQUEST_URL + "/containers";
 
     static {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/hello-rules-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(HttpsKieServerTestProvider.class.getResource("/kjars-sources/hello-rules-snapshot").getFile());
     }
 
     public static void testKieServerInfo(KieServerDeployment kieServerDeployment, boolean ssoScenario) {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/OptaplannerTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/OptaplannerTestProvider.java
@@ -50,7 +50,7 @@ public class OptaplannerTestProvider {
     private static final String CLASS_CLOUD_GENERATOR = "org.kie.server.testing.CloudBalancingGenerator";
 
     static {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(OptaplannerTestProvider.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile());
     }
 
     public static void testDeployFromKieServerAndExecuteSolver(KieServerDeployment kieServerDeployment) {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/ProcessTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/ProcessTestProvider.java
@@ -39,7 +39,7 @@ public class ProcessTestProvider {
     private static final int TASKS_PAGE_SIZE = 10000;
 
     static {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(ProcessTestProvider.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
     }
 
     public static void testDeployFromKieServerAndExecuteProcesses(KieServerDeployment kieServerDeployment) {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/SmartRouterTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/SmartRouterTestProvider.java
@@ -49,8 +49,8 @@ public class SmartRouterTestProvider {
     private static final String LOG_MESSAGE = "Log process was started";
 
     static {
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
-        MavenDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-101-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(SmartRouterTestProvider.class.getResource("/kjars-sources/definition-project-snapshot").getFile());
+        MavenDeployer.buildAndDeployMavenProject(SmartRouterTestProvider.class.getResource("/kjars-sources/definition-project-101-snapshot").getFile());
     }
 
     public static void testRouterLoadBalancing(WorkbenchDeployment workbenchDeployment, SmartRouterDeployment smartRouterDeployment,


### PR DESCRIPTION
To fix an issue with Java 11 where classloader of ClassLoader class doesn't see
resources stored in Kie cloud framework.