### PR TITLE
Some exclusions are needed to avoid duplicated classes issue

### DIFF
--- a/framework-cloud/framework-cloud-common/pom.xml
+++ b/framework-cloud/framework-cloud-common/pom.xml
@@ -87,6 +87,20 @@
     <dependency>
       <groupId>cz.xtf</groupId>
       <artifactId>utilities</artifactId>
+      <exclusions>
+          <exclusion>
+            <groupId>org.pacesys</groupId>
+            <artifactId>openstack4j-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.jms</groupId>
+            <artifactId>jms-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+          </exclusion>
+        </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
There are duplicated classes that have to be excluded for full maven install execution
@sutaakar done