### PR TITLE
[7.18.x] Add exclusions to avoid duplicate tests classes

### DIFF
--- a/framework-cloud/framework-cloud-common/pom.xml
+++ b/framework-cloud/framework-cloud-common/pom.xml
@@ -49,6 +49,10 @@
           <groupId>javax.xml.stream</groupId>
           <artifactId>stax-api</artifactId>
         </exclusion>
+        <exclusion>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson-provider</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -61,6 +65,12 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>business-central-tests-rest</artifactId>
+      <exclusions>
+        <exclusion>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson-provider</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- HttpsUtils -->
@@ -95,10 +105,6 @@
           <exclusion>
             <groupId>javax.jms</groupId>
             <artifactId>jms-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
           </exclusion>
         </exclusions>
     </dependency>

--- a/framework-cloud/framework-git/pom.xml
+++ b/framework-cloud/framework-git/pom.xml
@@ -23,6 +23,16 @@
     <dependency>
       <groupId>cz.xtf</groupId>
       <artifactId>utilities</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pacesys</groupId>
+          <artifactId>openstack4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.jms</groupId>
+          <artifactId>jms-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- GitHub client -->

--- a/framework-cloud/framework-maven/pom.xml
+++ b/framework-cloud/framework-maven/pom.xml
@@ -23,6 +23,16 @@
     <dependency>
       <groupId>cz.xtf</groupId>
       <artifactId>utilities</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pacesys</groupId>
+          <artifactId>openstack4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.jms</groupId>
+          <artifactId>jms-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>

--- a/framework-cloud/framework-openshift-apb/pom.xml
+++ b/framework-cloud/framework-openshift-apb/pom.xml
@@ -30,6 +30,16 @@
     <dependency>
       <groupId>cz.xtf</groupId>
       <artifactId>utilities</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pacesys</groupId>
+          <artifactId>openstack4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.jms</groupId>
+          <artifactId>jms-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/framework-cloud/framework-openshift-operator/pom.xml
+++ b/framework-cloud/framework-openshift-operator/pom.xml
@@ -30,6 +30,16 @@
     <dependency>
       <groupId>cz.xtf</groupId>
       <artifactId>utilities</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pacesys</groupId>
+          <artifactId>openstack4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.jms</groupId>
+          <artifactId>jms-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/framework-cloud/framework-openshift-templates/pom.xml
+++ b/framework-cloud/framework-openshift-templates/pom.xml
@@ -30,6 +30,16 @@
     <dependency>
       <groupId>cz.xtf</groupId>
       <artifactId>utilities</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pacesys</groupId>
+          <artifactId>openstack4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.jms</groupId>
+          <artifactId>jms-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/framework-cloud/framework-openshift/pom.xml
+++ b/framework-cloud/framework-openshift/pom.xml
@@ -26,6 +26,16 @@
     <dependency>
       <groupId>cz.xtf</groupId>
       <artifactId>utilities</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pacesys</groupId>
+          <artifactId>openstack4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.jms</groupId>
+          <artifactId>jms-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/SsoDeployer.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/SsoDeployer.java
@@ -36,6 +36,7 @@ import cz.xtf.openshift.OpenShiftUtils;
 import cz.xtf.sso.api.SsoApi;
 import cz.xtf.sso.api.SsoApiFactory;
 import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 
 public class SsoDeployer {
 
@@ -76,6 +77,10 @@ public class SsoDeployer {
                 openShiftUtil.client().imageStreams().inNamespace("openshift").withName(item.getMetadata().getName()).delete();
             });
             openShiftUtil.client().lists().inNamespace("openshift").create(resourceList);
+        } catch (KubernetesClientException e) {
+            if(!e.getMessage().contains("already exists")) {
+                throw new RuntimeException("Kubernetes Client Exception and Image stream not exists", e);
+            }
         } catch (MalformedURLException e) {
             throw new RuntimeException("Malformed resource URL", e);
         }

--- a/test-cloud/test-cloud-optaweb/pom.xml
+++ b/test-cloud/test-cloud-optaweb/pom.xml
@@ -54,6 +54,12 @@
       <groupId>org.kie.cloud</groupId>
       <artifactId>framework-cloud-common</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.ws.rs</groupId>
+          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.cloud</groupId>

--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -49,6 +49,12 @@
         <groupId>org.kie.server</groupId>
         <artifactId>kie-server-integ-tests-common</artifactId>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson-provider</artifactId>
+          </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>


### PR DESCRIPTION
Excluded resteasy-jackson-provider instead of resteasy-jackson2-provider
because of failing RH SSO integration tests.