### PR TITLE
Speed up current tests

### DIFF
--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
@@ -21,6 +21,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
+import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
@@ -30,12 +32,22 @@ import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.tests.common.ScenarioDeployer;
+import org.kie.cloud.tests.common.client.util.Kjar;
+import org.kie.cloud.tests.common.client.util.WorkbenchUtils;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.controller.client.KieServerControllerClient;
 import org.kie.cloud.maven.constants.MavenConstants;
 
 @Category({Smoke.class, JBPMOnly.class})
 public class ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest extends AbstractCloudIntegrationTest {
 
     private static ClusteredWorkbenchKieServerDatabasePersistentScenario deploymentScenario;
+
+    private static final String HELLO_RULES_CONTAINER_ID = "helloRules";
+    private static final String DEFINITION_PROJECT_CONTAINER_ID = "definition-project";
+    private static final String CLOUDBALANCE_CONTAINER_ID = "cloudbalance";
 
     @BeforeClass
     public static void initializeDeployment() {
@@ -50,6 +62,22 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTes
         }
         deploymentScenario.setLogFolderName(ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.class.getSimpleName());
         ScenarioDeployer.deployScenario(deploymentScenario);
+
+        // Workaround to speed test execution.
+        // Create all containers while Kie servers are turned off to avoid expensive respins.
+        KieServerControllerClient kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchDeployment());
+        KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
+        KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
+
+        deploymentScenario.getKieServerDeployment().scale(0);
+        deploymentScenario.getKieServerDeployment().waitForScale();
+
+        WorkbenchUtils.saveContainerSpec(kieControllerClient, serverInfo.getServerId(), serverInfo.getName(), HELLO_RULES_CONTAINER_ID, "hello-rules-alias", Kjar.HELLO_RULES_SNAPSHOT, KieContainerStatus.STARTED);
+        WorkbenchUtils.saveContainerSpec(kieControllerClient, serverInfo.getServerId(), serverInfo.getName(), DEFINITION_PROJECT_CONTAINER_ID, "definition-project-alias", Kjar.DEFINITION_SNAPSHOT, KieContainerStatus.STARTED);
+        WorkbenchUtils.saveContainerSpec(kieControllerClient, serverInfo.getServerId(), serverInfo.getName(), CLOUDBALANCE_CONTAINER_ID, "cloudbalance-alias", Kjar.CLOUD_BALANCE_SNAPSHOT, KieContainerStatus.STARTED);
+
+        deploymentScenario.getKieServerDeployment().scale(1);
+        deploymentScenario.getKieServerDeployment().waitForScale();
     }
 
     @AfterClass
@@ -59,18 +87,18 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTes
 
     @Test
     public void testRulesFromExternalMavenRepo() {
-        FireRulesTestProvider.testDeployFromKieServerAndFireRules(deploymentScenario.getKieServerDeployment());
+        FireRulesTestProvider.testFireRules(deploymentScenario.getKieServerDeployment(), HELLO_RULES_CONTAINER_ID);
     }
 
     @Test
     @Category(JBPMOnly.class)
     public void testProcessFromExternalMavenRepo() {
-        ProcessTestProvider.testDeployFromKieServerAndExecuteProcesses(deploymentScenario.getKieServerDeployment());
+        ProcessTestProvider.testExecuteProcesses(deploymentScenario.getKieServerDeployment(), DEFINITION_PROJECT_CONTAINER_ID);
     }
 
     @Test
-    public void testSolverFromExternalMavenRepo() {
-        OptaplannerTestProvider.testDeployFromKieServerAndExecuteSolver(deploymentScenario.getKieServerDeployment());
+    public void testSolverFromExternalMavenRepo() throws Exception {
+        OptaplannerTestProvider.testExecuteSolver(deploymentScenario.getKieServerDeployment(), CLOUDBALANCE_CONTAINER_ID);
     }
 
     @Test
@@ -81,7 +109,8 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTes
     @Test
     public void testKieServerHttps() {
         HttpsKieServerTestProvider.testKieServerInfo(deploymentScenario.getKieServerDeployment(), false);
-        HttpsKieServerTestProvider.testDeployContainer(deploymentScenario.getKieServerDeployment(), false);
+        // Skipped as the check is too time consuming, the HTTPS functionality is verified by testKieServerInfo()
+        // HttpsKieServerTestProvider.testDeployContainer(deploymentScenario.getKieServerDeployment(), false);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
@@ -15,12 +15,15 @@
 
 package org.kie.cloud.integrationtests.smoke;
 
+import java.time.Duration;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
-import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
+import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.integrationtests.testproviders.FireRulesTestProvider;
@@ -28,13 +31,24 @@ import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
 import org.kie.cloud.integrationtests.testproviders.OptaplannerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
+import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
+import org.kie.cloud.tests.common.ScenarioDeployer;
+import org.kie.cloud.tests.common.client.util.Kjar;
+import org.kie.cloud.tests.common.client.util.WorkbenchUtils;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.controller.client.KieServerControllerClient;
 
 @Category(Smoke.class)
 public class WorkbenchKieServerPersistentScenarioIntegrationTest extends AbstractCloudIntegrationTest {
 
     private static WorkbenchKieServerScenario deploymentScenario;
+
+    private static final String HELLO_RULES_CONTAINER_ID = "helloRules";
+    private static final String DEFINITION_PROJECT_CONTAINER_ID = "definition-project";
+    private static final String CLOUDBALANCE_CONTAINER_ID = "cloudbalance";
 
     @BeforeClass
     public static void initializeDeployment() {
@@ -43,6 +57,22 @@ public class WorkbenchKieServerPersistentScenarioIntegrationTest extends Abstrac
                                                       .build();
         deploymentScenario.setLogFolderName(WorkbenchKieServerPersistentScenarioIntegrationTest.class.getSimpleName());
         ScenarioDeployer.deployScenario(deploymentScenario);
+
+        // Workaround to speed test execution.
+        // Create all containers while Kie servers are turned off to avoid expensive respins.
+        KieServerControllerClient kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchDeployment());
+        KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
+        KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
+
+        deploymentScenario.getKieServerDeployment().scale(0);
+        deploymentScenario.getKieServerDeployment().waitForScale();
+
+        WorkbenchUtils.saveContainerSpec(kieControllerClient, serverInfo.getServerId(), serverInfo.getName(), HELLO_RULES_CONTAINER_ID, "hello-rules-alias", Kjar.HELLO_RULES_SNAPSHOT, KieContainerStatus.STARTED);
+        WorkbenchUtils.saveContainerSpec(kieControllerClient, serverInfo.getServerId(), serverInfo.getName(), DEFINITION_PROJECT_CONTAINER_ID, "definition-project-alias", Kjar.DEFINITION_SNAPSHOT, KieContainerStatus.STARTED);
+        WorkbenchUtils.saveContainerSpec(kieControllerClient, serverInfo.getServerId(), serverInfo.getName(), CLOUDBALANCE_CONTAINER_ID, "cloudbalance-alias", Kjar.CLOUD_BALANCE_SNAPSHOT, KieContainerStatus.STARTED);
+
+        deploymentScenario.getKieServerDeployment().scale(1);
+        deploymentScenario.getKieServerDeployment().waitForScale();
     }
 
     @AfterClass
@@ -52,18 +82,18 @@ public class WorkbenchKieServerPersistentScenarioIntegrationTest extends Abstrac
 
     @Test
     public void testRulesFromExternalMavenRepo() {
-        FireRulesTestProvider.testDeployFromKieServerAndFireRules(deploymentScenario.getKieServerDeployment());
+        FireRulesTestProvider.testFireRules(deploymentScenario.getKieServerDeployment(), HELLO_RULES_CONTAINER_ID);
     }
 
     @Test
     @Category(JBPMOnly.class)
     public void testProcessFromExternalMavenRepo() {
-        ProcessTestProvider.testDeployFromKieServerAndExecuteProcesses(deploymentScenario.getKieServerDeployment());
+        ProcessTestProvider.testExecuteProcesses(deploymentScenario.getKieServerDeployment(), DEFINITION_PROJECT_CONTAINER_ID);
     }
 
     @Test
-    public void testSolverFromExternalMavenRepo() {
-        OptaplannerTestProvider.testDeployFromKieServerAndExecuteSolver(deploymentScenario.getKieServerDeployment());
+    public void testSolverFromExternalMavenRepo() throws Exception {
+        OptaplannerTestProvider.testExecuteSolver(deploymentScenario.getKieServerDeployment(), CLOUDBALANCE_CONTAINER_ID);
     }
 
     @Test
@@ -74,7 +104,8 @@ public class WorkbenchKieServerPersistentScenarioIntegrationTest extends Abstrac
     @Test
     public void testKieServerHttps() {
         HttpsKieServerTestProvider.testKieServerInfo(deploymentScenario.getKieServerDeployment(), false);
-        HttpsKieServerTestProvider.testDeployContainer(deploymentScenario.getKieServerDeployment(), false);
+        // Skipped as the check is too time consuming, the HTTPS functionality is verified by testKieServerInfo()
+        // HttpsKieServerTestProvider.testDeployContainer(deploymentScenario.getKieServerDeployment(), false);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/FireRulesTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/FireRulesTestProvider.java
@@ -90,11 +90,13 @@ public class FireRulesTestProvider {
             WorkbenchUtils.saveContainerSpec(kieControllerClient, serverInfo.getServerId(), serverInfo.getName(), containerId, containerAlias, Kjar.HELLO_RULES, KieContainerStatus.STARTED);
 
             KieServerClientProvider.waitForContainerStart(kieServerDeployment, containerId);
+            kieServerDeployment.waitForContainerRespin();
 
             testFireRules(kieServerDeployment, containerId);
         } finally {
             gitProvider.deleteGitRepository(repositoryName);
             kieControllerClient.deleteContainerSpec(serverInfo.getServerId(), containerId);
+            kieServerDeployment.waitForContainerRespin();
         }
     }
 


### PR DESCRIPTION
Tests now takes much more time due to OpenShiftStartupStrategy changes.
These adjustments make test execution a bit faster.