### PR TITLE
Use intended number of replicas when waiting for router

### DIFF
--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/KieServerOperatorDeployment.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/KieServerOperatorDeployment.java
@@ -59,7 +59,7 @@ public class KieServerOperatorDeployment extends KieServerDeploymentImpl {
         }
 
         waitUntilAllPodsAreReadyAndRunning(replicas);
-        if (getInstances().size() > 0) {
+        if (replicas > 0) {
             RouterUtil.waitForRouter(getUrl());
         }
     }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/SmartRouterOperatorDeployment.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/SmartRouterOperatorDeployment.java
@@ -56,7 +56,7 @@ public class SmartRouterOperatorDeployment extends SmartRouterDeploymentImpl {
         }
 
         waitUntilAllPodsAreReadyAndRunning(replicas);
-        if (getInstances().size() > 0) {
+        if (replicas > 0) {
             RouterUtil.waitForRouter(getUrl());
         }
     }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/WorkbenchOperatorDeployment.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/WorkbenchOperatorDeployment.java
@@ -56,7 +56,7 @@ public class WorkbenchOperatorDeployment extends WorkbenchDeploymentImpl {
         }
 
         waitUntilAllPodsAreReadyAndRunning(replicas);
-        if (getInstances().size() > 0) {
+        if (replicas > 0) {
             RouterUtil.waitForRouter(getUrl());
         }
     }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/WorkbenchRuntimeOperatorDeployment.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/WorkbenchRuntimeOperatorDeployment.java
@@ -56,7 +56,7 @@ public class WorkbenchRuntimeOperatorDeployment extends WorkbenchRuntimeDeployme
         }
 
         waitUntilAllPodsAreReadyAndRunning(replicas);
-        if (getInstances().size() > 0) {
+        if (replicas > 0) {
             RouterUtil.waitForRouter(getUrl());
         }
     }


### PR DESCRIPTION
Sometimes pods can still terminate when this line of is reached,
causing router check to be invoked even when scaled to 0