### PR TITLE
Cherry-pick: BAQE-904: Store logs for pods that fail to deploy (#413)

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/Instance.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/Instance.java
@@ -51,6 +51,13 @@ public interface Instance {
     boolean isRunning();
 
     /**
+     * Return true if instance is existing on Openshift.
+     *
+     * @return True if instance is existing on Openshift.
+     */
+    boolean exists();
+
+    /**
      * Return started time of currently running instance.
      *
      * @return Started time.

--- a/framework-cloud/framework-cloud-common/src/main/java/org/kie/cloud/common/logs/InstanceLogUtil.java
+++ b/framework-cloud/framework-cloud-common/src/main/java/org/kie/cloud/common/logs/InstanceLogUtil.java
@@ -16,6 +16,7 @@
 package org.kie.cloud.common.logs;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -34,16 +35,7 @@ public class InstanceLogUtil {
     private static final String LOG_SUFFIX = ".log";
 
     public static void writeInstanceLogs(Instance instance, String customLogFolderName) {
-        File outputDirectory = new File(System.getProperty(INSTANCES_LOGS_OUTPUT_DIRECTORY, DEFAULT_LOG_OUTPUT_DIRECTORY));
-        if (!outputDirectory.isDirectory()) {
-            outputDirectory.mkdir();
-        }
-        outputDirectory = new File(outputDirectory, customLogFolderName);
-        if (!outputDirectory.isDirectory()) {
-            outputDirectory.mkdir();
-        }
-
-        File logFile = new File(outputDirectory, instance.getName() + LOG_SUFFIX);
+        File logFile = getOutputFile(instance.getName(), customLogFolderName);
         try {
             FileUtils.write(logFile, instance.getLogs(), "UTF-8");
         } catch (Exception e) {
@@ -52,7 +44,7 @@ public class InstanceLogUtil {
     }
 
     public static void writeDeploymentLogs(DeploymentScenario<?> deploymentScenario) {
-        for(Deployment deployment : deploymentScenario.getDeployments()) {
+        for (Deployment deployment : deploymentScenario.getDeployments()) {
             if (deployment != null) {
                 List<Instance> instances = deployment.getInstances();
                 for (Instance instance : instances) {
@@ -60,5 +52,20 @@ public class InstanceLogUtil {
                 }
             }
         }
+    }
+
+    public static void appendInstanceLogLines(String instanceName, Collection<String> lines, String customLogFolderName) {
+        File logFile = getOutputFile(instanceName, customLogFolderName);
+        try {
+            FileUtils.writeLines(logFile, "UTF-8", lines, true);
+        } catch (Exception e) {
+            logger.error("Error writting instance logs", e);
+        }
+    }
+
+    private static File getOutputFile(String instanceName, String customLogFolderName) {
+        File outputDirectory = new File(System.getProperty(INSTANCES_LOGS_OUTPUT_DIRECTORY, DEFAULT_LOG_OUTPUT_DIRECTORY), customLogFolderName);
+        outputDirectory.mkdirs();
+        return new File(outputDirectory, instanceName + LOG_SUFFIX);
     }
 }

--- a/framework-cloud/framework-openshift/pom.xml
+++ b/framework-cloud/framework-openshift/pom.xml
@@ -32,6 +32,10 @@
       <groupId>cz.xtf</groupId>
       <artifactId>builder</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
 
     <!-- RH SSO dependencies  -->
     <dependency>

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/OpenShiftInstance.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/OpenShiftInstance.java
@@ -15,16 +15,17 @@
  */
 package org.kie.cloud.openshift.deployment;
 
-import static org.kie.cloud.openshift.util.CommandUtil.runCommandImpl;
-
 import java.time.Instant;
+import java.util.Objects;
 
 import cz.xtf.core.openshift.OpenShift;
 import io.fabric8.kubernetes.api.model.ContainerStateRunning;
 import io.fabric8.kubernetes.api.model.Pod;
-
 import org.kie.cloud.api.deployment.CommandExecutionResult;
 import org.kie.cloud.api.deployment.Instance;
+import rx.Observable;
+
+import static org.kie.cloud.openshift.util.CommandUtil.runCommandImpl;
 
 public class OpenShiftInstance implements Instance {
 
@@ -52,13 +53,19 @@ public class OpenShiftInstance implements Instance {
         return name;
     }
 
-    @Override public CommandExecutionResult runCommand(String... command) {
+    @Override
+    public CommandExecutionResult runCommand(String... command) {
         return runCommandImpl(openshift.pods().withName(name), command);
     }
 
     @Override
     public boolean isRunning() {
-        return getContainerRunningState() != null;
+        return exists() && getContainerRunningState() != null;
+    }
+
+    @Override
+    public boolean exists() {
+        return Objects.nonNull(openshift.getPod(name));
     }
 
     @Override
@@ -80,5 +87,9 @@ public class OpenShiftInstance implements Instance {
     public String getLogs() {
         Pod pod = openshift.getPod(name);
         return openshift.getPodLog(pod);
+    }
+
+    public Observable<String> observeLogs() {
+        return openshift.observePodLog(openshift.getPod(getName()));
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/log/InstancesLogCollectorRunnable.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/log/InstancesLogCollectorRunnable.java
@@ -1,0 +1,128 @@
+package org.kie.cloud.openshift.log;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.kie.cloud.api.deployment.Instance;
+import org.kie.cloud.common.logs.InstanceLogUtil;
+import org.kie.cloud.openshift.deployment.OpenShiftInstance;
+import org.kie.cloud.openshift.resource.Project;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InstancesLogCollectorRunnable implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(InstancesLogCollectorRunnable.class);
+
+    private static final Integer DEFAULT_OBERVABLE_BUFFER_IN_SECONDS = 5;
+
+    private Project project;
+    private String logFolderName;
+
+    protected ExecutorService executorService = Executors.newCachedThreadPool();
+    protected Set<OpenShiftInstance> observedInstances = Collections.synchronizedSet(new HashSet<>());
+
+    public InstancesLogCollectorRunnable(Project project, String logFolderName) {
+        super();
+        this.project = project;
+        this.logFolderName = logFolderName;
+    }
+
+    @Override
+    public void run() {
+        // Check for new instances and observe on them
+        project.getAllInstances()
+               .stream()
+               .filter(instance -> instance instanceof OpenShiftInstance)
+               .map(instance -> (OpenShiftInstance) instance)
+               // Filter non observed instances
+               .filter(instance -> !isInstanceObserved(instance))
+               // Observe instance logs
+               .forEach(this::observeInstanceLog);
+    }
+
+    public void closeAndFlushRemainingInstanceCollectors(int waitForCompletionInMs) {
+        // Make a copy before stopping collector threads
+        List<Instance> instances = new ArrayList<>(observedInstances);
+
+        // Stop all collectors
+        executorService.shutdown(); // Disable new tasks from being submitted
+        try {
+            // Wait a while for existing tasks to terminate
+            if (!executorService.awaitTermination(waitForCompletionInMs, TimeUnit.MILLISECONDS)) {
+                logger.warn("Log collector Threadpool cannot stop. Force shutdown ...");
+                executorService.shutdownNow(); // Cancel currently executing tasks
+                // Wait a while for tasks to respond to being cancelled
+                if (!executorService.awaitTermination(waitForCompletionInMs, TimeUnit.MILLISECONDS))
+                    logger.error("Log collector Threadpool did not terminate");
+            } else {
+                logger.debug("Log collector Threadpool stopped correctly");
+            }
+        } catch (InterruptedException ie) {
+            // (Re-)Cancel if current thread also interrupted
+            executorService.shutdownNow();
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
+        } finally {
+            // Finally, flush logs to be sure we have the last state of running pods
+            instances.forEach(this::flushInstanceLogs);
+        }
+    }
+
+    private void observeInstanceLog(OpenShiftInstance instance) {
+        Future<?> future = executorService.submit(() -> {
+            try {
+                instance.observeLogs().buffer(DEFAULT_OBERVABLE_BUFFER_IN_SECONDS, TimeUnit.SECONDS)
+                        .subscribe(logLines -> instanceLogLines(instance, logLines), error -> {
+                            throw new RuntimeException(error);
+                        });
+            } catch (Exception e) {
+                logger.error("Problem observing logs for instance " + instance.getName(), e);
+            } finally {
+                removeInstanceObserved(instance);
+            }
+        });
+        setInstanceAsObserved(instance, future);
+    }
+
+    private void instanceLogLines(OpenShiftInstance instance, Collection<String> logLines) {
+        logger.trace("Write log lines {}", logLines);
+        InstanceLogUtil.appendInstanceLogLines(instance.getName(), logLines, logFolderName);
+    }
+
+    private void flushInstanceLogs(Instance instance) {
+        logger.trace("Flushing logs from {}", instance.getName());
+        if (instance.exists()) {
+            logger.trace("Flush logs from {}", instance.getName());
+            InstanceLogUtil.writeInstanceLogs(instance, logFolderName);
+        } else {
+            logger.trace("Ignoring instance {} as not running", instance.getName());
+        }
+    }
+
+    private boolean isInstanceObserved(OpenShiftInstance instance) {
+        synchronized (observedInstances) {
+            return this.observedInstances.stream().map(Instance::getName)
+                                         .anyMatch(name -> name.equals(instance.getName()));
+        }
+    }
+
+    private void setInstanceAsObserved(OpenShiftInstance instance, Future<?> future) {
+        logger.trace("Observe instance {}", instance.getName());
+        this.observedInstances.add(instance);
+    }
+
+    private void removeInstanceObserved(OpenShiftInstance instance) {
+        logger.trace("finished observing instance {}", instance.getName());
+        this.observedInstances.remove(instance);
+    }
+
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import cz.xtf.core.openshift.OpenShift;
+import org.kie.cloud.api.deployment.Instance;
 
 /**
  * Project representation.
@@ -55,7 +56,7 @@ public interface Project extends AutoCloseable {
      * @param image APB Image to be provision
      * @param extraVars Map of extra vars to override default values from the APB image
      */
-    public void processApbRun(String image, Map<String,String> extraVars);
+    public void processApbRun(String image, Map<String, String> extraVars);
 
     /**
      * Create resources from YAML file using command line client.
@@ -128,4 +129,12 @@ public interface Project extends AutoCloseable {
      * @return Output of oc
      */
     public String runOcCommandAsAdmin(String... args);
+
+    /**
+     * Return list of all scheduled instances in the project.
+     *
+     * @return List of Instances
+     * @see Instance
+     */
+    public List<Instance> getAllInstances();
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/OpenShiftScenario.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/OpenShiftScenario.java
@@ -19,15 +19,18 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import org.kie.cloud.api.deployment.Deployment;
 import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.api.scenario.DeploymentScenarioListener;
-import org.kie.cloud.common.logs.InstanceLogUtil;
 import org.kie.cloud.openshift.OpenShiftController;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.constants.images.imagestream.ImageStreamProvider;
+import org.kie.cloud.openshift.log.InstancesLogCollectorRunnable;
 import org.kie.cloud.openshift.resource.Project;
 import org.kie.cloud.openshift.template.OpenShiftTemplate;
 import org.slf4j.Logger;
@@ -35,10 +38,15 @@ import org.slf4j.LoggerFactory;
 
 public abstract class OpenShiftScenario<T extends DeploymentScenario<T>> implements DeploymentScenario<T> {
 
+    private static final Integer DEFAULT_SCHEDULED_FIX_RATE_LOG_COLLECTOR_IN_SECONDS = 5;
+
     protected String projectName;
     protected Project project;
     private String logFolderName;
     private boolean createImageStreams;
+
+    private ScheduledExecutorService logCollectorExecutorService;
+    private InstancesLogCollectorRunnable instancesLogCollectorRunnable;
 
     private List<DeploymentScenarioListener<T>> deploymentScenarioListeners = new ArrayList<>();
 
@@ -81,6 +89,12 @@ public abstract class OpenShiftScenario<T extends DeploymentScenario<T>> impleme
         logger.info("Creating project " + projectName);
         project = OpenShiftController.createProject(projectName);
 
+        // Init the log collector
+        logger.info("Launch instances log collector on project {}", projectName);
+        logCollectorExecutorService = Executors.newScheduledThreadPool(1);
+        instancesLogCollectorRunnable = new InstancesLogCollectorRunnable(project, getLogFolderName());
+        logCollectorExecutorService.scheduleWithFixedDelay(instancesLogCollectorRunnable, 0, DEFAULT_SCHEDULED_FIX_RATE_LOG_COLLECTOR_IN_SECONDS, TimeUnit.SECONDS);
+
         logger.info("Creating generally used secret from " + OpenShiftTemplate.SECRET.getTemplateUrl().toString());
         project.processTemplateAndCreateResources(OpenShiftTemplate.SECRET.getTemplateUrl(), Collections.singletonMap(OpenShiftConstants.SECRET_NAME, OpenShiftConstants.getKieApplicationSecretName()));
 
@@ -104,11 +118,19 @@ public abstract class OpenShiftScenario<T extends DeploymentScenario<T>> impleme
     @Override
     public void undeploy() {
         try {
-            InstanceLogUtil.writeDeploymentLogs(this);
+            logger.info("Release log collector(s)");
+            try {
+                logCollectorExecutorService.shutdownNow();
+                logCollectorExecutorService = null;
+                instancesLogCollectorRunnable.closeAndFlushRemainingInstanceCollectors(5000);
+            } catch (Exception e) {
+                logger.error("Error killing log collector thread", e);
+            }
 
             project.delete();
             project.close();
         } catch (Exception e) {
+            logger.error("Error undeploy", e);
             throw new RuntimeException("Error while undeploying scenario.", e);
         }
     }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/OpenshiftInstanceUtil.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/OpenshiftInstanceUtil.java
@@ -1,0 +1,20 @@
+package org.kie.cloud.openshift.util;
+
+import cz.xtf.core.openshift.OpenShift;
+import io.fabric8.kubernetes.api.model.Pod;
+import org.kie.cloud.openshift.deployment.OpenShiftInstance;
+
+public class OpenshiftInstanceUtil {
+
+    /**
+     * Create an instance 
+     * @param openShift
+     * @param namespace
+     * @param pod
+     * @return
+     */
+    public static OpenShiftInstance createInstance(OpenShift openShift, String namespace, Pod pod) {
+        String instanceName = pod.getMetadata().getName();
+        return new OpenShiftInstance(openShift, namespace, instanceName);
+    }
+}

--- a/framework-cloud/framework-openshift/src/test/java/org/kie/cloud/openshift/log/InstancesLogCollectorRunnableTest.java
+++ b/framework-cloud/framework-openshift/src/test/java/org/kie/cloud/openshift/log/InstancesLogCollectorRunnableTest.java
@@ -1,0 +1,200 @@
+package org.kie.cloud.openshift.log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.cloud.api.deployment.Instance;
+import org.kie.cloud.openshift.deployment.OpenShiftInstance;
+import org.kie.cloud.openshift.resource.Project;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import rx.Observable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InstancesLogCollectorRunnableTest {
+
+    private static final String LOG_FOLDER_NAME = "LOG_FOLDER_NAME";
+    private static final String PROJECT_NAME = "PROJECT_NAME";
+    private static final String LOG_OUTPUT_DIRECTORY = "instances";
+    private static final String LOG_SUFFIX = ".log";
+
+    private static final Integer DEFAULT_WAIT_FOR_COMPLETION_IN_MS = 5000;
+
+    @Mock
+    Project projectMock;
+
+    InstancesLogCollectorRunnable cut;
+
+    @Before
+    public void setUp() throws IOException {
+        FileUtils.deleteDirectory(new File(LOG_OUTPUT_DIRECTORY));
+
+        Mockito.when(projectMock.getName()).thenReturn(PROJECT_NAME);
+
+        cut = new InstancesLogCollectorRunnable(projectMock, LOG_FOLDER_NAME);
+    }
+
+    @Test
+    public void oneInstanceRunning() {
+        setObserveLogCallable(setInstanceMocks("BONJOUR"), null);
+        ExecutorService executorService = retrieveExecutorService();
+
+        cut.run();
+
+        assertEquals(1, ((ThreadPoolExecutor) executorService).getActiveCount());
+        checkObservedInstances("BONJOUR");
+
+        cut.closeAndFlushRemainingInstanceCollectors(DEFAULT_WAIT_FOR_COMPLETION_IN_MS);
+
+        assertEquals(0, ((ThreadPoolExecutor) executorService).getActiveCount());
+        checkObservedInstances();
+
+        checkLog("BONJOUR", true);
+
+    }
+
+    @Test
+    public void oneInstanceRunningRunnableExecutedTwice() {
+        setObserveLogCallable(setInstanceMocks("BONJOUR"), null);
+        ExecutorService executorService = retrieveExecutorService();
+
+        cut.run();
+        cut.run();
+
+        assertEquals(1, ((ThreadPoolExecutor) executorService).getActiveCount());
+        checkObservedInstances("BONJOUR");
+
+        cut.closeAndFlushRemainingInstanceCollectors(DEFAULT_WAIT_FOR_COMPLETION_IN_MS);
+
+        assertEquals(0, ((ThreadPoolExecutor) executorService).getActiveCount());
+        checkObservedInstances();
+
+        checkLog("BONJOUR", true);
+    }
+
+    @Test
+    public void manyInstancesRunning() {
+        List<OpenShiftInstance> instances = setInstanceMocks("BONJOUR", "HELLO", "BUON GIORNO", "HALLO", "DOBRY DEN");
+        setObserveLogCallable(instances, 1000); // Add small tempo to be sure the check after on the number of threads/observed instances is correct 
+
+        ExecutorService executorService = retrieveExecutorService();
+
+        cut.run();
+
+        assertEquals(5, ((ThreadPoolExecutor) executorService).getActiveCount());
+        checkObservedInstances("BONJOUR", "HELLO", "BUON GIORNO", "HALLO", "DOBRY DEN");
+
+        cut.closeAndFlushRemainingInstanceCollectors(DEFAULT_WAIT_FOR_COMPLETION_IN_MS);
+
+        assertEquals(0, ((ThreadPoolExecutor) executorService).getActiveCount());
+        checkObservedInstances();
+
+        checkLog("BONJOUR", true);
+        checkLog("HELLO", true);
+        checkLog("BUON GIORNO", true);
+        checkLog("HALLO", true);
+        checkLog("DOBRY DEN", true);
+    }
+
+    @Test
+    public void killBeforeFinished() {
+        setObserveLogCallable(setInstanceMocks("BONJOUR"), 2000);
+        ExecutorService executorService = retrieveExecutorService();
+
+        cut.run();
+
+        assertEquals(1, ((ThreadPoolExecutor) executorService).getActiveCount());
+        checkObservedInstances("BONJOUR");
+
+        // Here we wait less than the time for the message to be delivered
+        cut.closeAndFlushRemainingInstanceCollectors(1000);
+
+        assertEquals(0, ((ThreadPoolExecutor) executorService).getActiveCount());
+        checkObservedInstances();
+
+        checkLog("BONJOUR", false);
+    }
+
+    private List<OpenShiftInstance> setInstanceMocks(String... messages) {
+        List<OpenShiftInstance> instances = Arrays.asList(messages)
+                                                  .stream()
+                                                  .map(this::createInstanceMock)
+                                                  .collect(Collectors.toList());
+
+        Mockito.when(projectMock.getAllInstances())
+               .thenReturn(instances.stream()
+                                    .map(inst -> (Instance) inst)
+                                    .collect(Collectors.toList()));
+
+        return instances;
+    }
+
+    private OpenShiftInstance createInstanceMock(String message) {
+        OpenShiftInstance instanceMock = Mockito.mock(OpenShiftInstance.class);
+        Mockito.when(instanceMock.getName()).thenReturn(message);
+        return instanceMock;
+    }
+
+    private void setObserveLogCallable(List<OpenShiftInstance> instances, Integer waitForMessage) {
+        instances.forEach(instance -> {
+            Mockito.when(instance.observeLogs()).then((invocation) -> {
+                return Observable.fromCallable(() -> {
+                    if (Objects.nonNull(waitForMessage)) {
+                        Thread.sleep(waitForMessage);
+                    }
+                    return instance.getName();
+                });
+            });
+        });
+    }
+
+    private ExecutorService retrieveExecutorService() {
+        return cut.executorService;
+    }
+
+    private void checkObservedInstances(String... instanceNames) {
+        assertEquals(instanceNames.length, cut.observedInstances.size());
+        Arrays.asList(instanceNames).forEach(instanceName -> {
+            assertTrue("Instance with name " + instanceName + " is not observed...", cut.observedInstances.stream().map(Instance::getName).anyMatch(instanceName::equals));
+        });
+    }
+
+    private void checkLog(String message, boolean exist) {
+        assertEquals(exist, isLogExisting(message));
+        if (exist) {
+            assertEquals("Log for " + message + "is wrong", message, readLog(message));
+        }
+    }
+
+    private static boolean isLogExisting(String instanceName) {
+        return getOutputFile(instanceName).exists();
+    }
+
+    private static String readLog(String instanceName) {
+        try {
+            return FileUtils.readFileToString(getOutputFile(instanceName), "UTF-8").trim();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static File getOutputFile(String instanceName) {
+        File outputDirectory = new File(LOG_OUTPUT_DIRECTORY, LOG_FOLDER_NAME);
+        outputDirectory.mkdirs();
+        return new File(outputDirectory, instanceName + LOG_SUFFIX);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <version.jgit>4.11.0.201803080745-r</version.jgit>
 
     <version.cz.xtf>0.12</version.cz.xtf>
+    <version.rx-java>1.3.0</version.rx-java> <!-- rxjava dependency version depends on version.cz.xtf used -->
     <version.org.keycloak>4.8.3.Final</version.org.keycloak>
     <version.org.projectlombok>1.16.10</version.org.projectlombok>
     <version.org.jboss.jboss-dmr>1.5.0.Final</version.org.jboss.jboss-dmr>
@@ -211,12 +212,17 @@
       <dependency>
         <groupId>cz.xtf</groupId>
         <artifactId>builder</artifactId>
-         <version>${version.cz.xtf}</version>
+        <version>${version.cz.xtf}</version>
       </dependency>
       <dependency>
         <groupId>cz.xtf</groupId>
         <artifactId>http-client</artifactId>
-         <version>${version.cz.xtf}</version>
+        <version>${version.cz.xtf}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.reactivex</groupId>
+        <artifactId>rxjava</artifactId>
+        <version>${version.rx-java}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
BAQE-904: Setup parallel thread(s) to log the pods

On scenario deployment, a thread is started (with a 5s repeating
schedule) to get the different started pods of a project and put an
observable thread on each of them.
On scenario undeploy, all created threads are stopped, if not already
done.

Other:
* Stop all observing threads when scenario is over
* Flush logs from pods still running, to be sure we get the last logs
* Use executor shutdown functionality
* Added test for InstancesLogCollectorRunnable
* Added synchronization on iterating the observed instances to avoid
ConcurrentModificationException

Signed-off-by: tradisso <tradisso@tradisso.remote.csb>