### PR TITLE
Use Cekit build for driver images

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
@@ -61,9 +61,6 @@ public class DeploymentConstants implements Constants {
     public static final String CUSTOM_TRUSTED_KEYSTORE_ALIAS = "custom.trusted.keystore.alias";
     public static final String CUSTOM_TRUSTED_KEYSTORE_PWD = "custom.trusted.keystore.pwd";
 
-    // URL for external registry containing driver images for external DB tests
-    public static final String EXTERNAL_REGISTRY_URL = "external.registry.url";
-
     public static String getKieServerUser() {
         return System.getProperty(KIE_SERVER_USER);
     }
@@ -169,10 +166,6 @@ public class DeploymentConstants implements Constants {
 
     public static String getCustomTrustedKeystorePwd() {
         return System.getProperty(CUSTOM_TRUSTED_KEYSTORE_PWD);
-    }
-
-    public static String getExternalRegistryUrl() {
-        return System.getProperty(EXTERNAL_REGISTRY_URL);
     }
 
     @Override

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
@@ -264,8 +264,14 @@ public class OpenShiftConstants implements Constants {
     }
 
     public static File getKieJdbcDriverScriptsFolder() {
-        String kieJdbcDriverScriptsFolder = System.getProperty(KIE_JDBC_DRIVER_SCRIPTS);
-        return new File(kieJdbcDriverScriptsFolder);
+        String kieJdbcDriverScriptsFolderPath = System.getProperty(KIE_JDBC_DRIVER_SCRIPTS);
+        File kieJdbcDriverScriptsFolder = new File(kieJdbcDriverScriptsFolderPath);
+
+        if (!kieJdbcDriverScriptsFolder.exists()) {
+            throw new RuntimeException("JDBC driver script folder " + kieJdbcDriverScriptsFolder.getAbsolutePath() + " doesn't exist.");
+        }
+
+        return kieJdbcDriverScriptsFolder;
     }
 
     public static URL getKieJdbcDriverBinaryUrl() {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/AbstractExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/AbstractExternalDriver.java
@@ -15,45 +15,22 @@
 
 package org.kie.cloud.openshift.database.driver;
 
-import java.io.File;
 import java.net.URL;
-
-import org.kie.cloud.openshift.constants.OpenShiftConstants;
 
 public abstract class AbstractExternalDriver implements ExternalDriver {
 
-    private static final String ARTIFACT_MVN_REPO_RELATIVE_PATH = "drivers";
+    @Override
+    public String getSourceDockerTag() {
+        return "kiegroup/" + getImageName() + ":" + getImageVersion();
+    }
 
     @Override
-    public String getDockerTag(URL dockerUrl) {
+    public String getTargetDockerTag(URL dockerUrl) {
         return dockerUrl.getHost() + ":" + dockerUrl.getPort() + "/kie-server/" + getImageName() + ":" + getImageVersion();
     }
 
     @Override
-    public String getDockerImageBuildCommand(File kieJdbcDriverScriptsFolder, URL dockerUrl) {
-        if (!kieJdbcDriverScriptsFolder.exists()) {
-            throw new RuntimeException("JDBC driver script folder " + kieJdbcDriverScriptsFolder.getAbsolutePath() + " doesn't exist.");
-        }
-
-        File kieJdbcDriverDockerDir = new File(kieJdbcDriverScriptsFolder, getDockerFileRelativePath());
-        File kieJdbcDriverDockerFile = new File(kieJdbcDriverDockerDir, "Dockerfile");
-        if (!kieJdbcDriverDockerFile.exists()) {
-            throw new RuntimeException("JDBC driver Dockerfile " + kieJdbcDriverDockerFile.getAbsolutePath() + " doesn't exist.");
-        }
-
-        return "docker build -f " + kieJdbcDriverDockerFile.getAbsolutePath() + " --build-arg ARTIFACT_MVN_REPO=" + ARTIFACT_MVN_REPO_RELATIVE_PATH + " -t " + getDockerTag(dockerUrl) + " " + kieJdbcDriverScriptsFolder.getAbsolutePath();
+    public String getCekitImageBuildCommand() {
+        return "make build " + getName();
     }
-
-    @Override
-    public File getDriverBinaryFileLocation() {
-        File kieJdbcDriverScriptsFolder = OpenShiftConstants.getKieJdbcDriverScriptsFolder();
-        return new File(kieJdbcDriverScriptsFolder, ARTIFACT_MVN_REPO_RELATIVE_PATH + "/" + getDriverBinaryFileLocationInArtifactRepo());
-    }
-
-    /**
-     * Values returned by this method have to be same as binary file locations defined in driver scripts! 
-     *
-     * @return Path to the driver binary file in "artifact repo" placed within driver scripts folder.
-     */
-    protected abstract String getDriverBinaryFileLocationInArtifactRepo();
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/Db2ExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/Db2ExternalDriver.java
@@ -18,32 +18,17 @@ package org.kie.cloud.openshift.database.driver;
 public class Db2ExternalDriver extends AbstractExternalDriver {
 
     @Override
+    public String getName() {
+        return "db2";
+    }
+
+    @Override
     public String getImageName() {
-        return "db2-driver-image";
+        return "jboss-kie-db2-extension-openshift-image";
     }
 
     @Override
     public String getImageVersion() {
-        return "10.5";
-    }
-
-    @Override
-    public String getDockerFileRelativePath() {
-        return "db2-driver-image";
-    }
-
-    @Override
-    public String getCustomInstallDirectories() {
-        return "db2-driver/extensions";
-    }
-
-    @Override
-    public String getSourceImagePath() {
-        return "/extensions:db2-driver/";
-    }
-
-    @Override
-    protected String getDriverBinaryFileLocationInArtifactRepo() {
-        return "com/ibm/db2/jcc/db2jcc4/10.5/db2jcc4-10.5.jar";
+        return "11.1.4.4";
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/ExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/ExternalDriver.java
@@ -24,6 +24,11 @@ import java.net.URL;
 public interface ExternalDriver {
 
     /**
+     * @return Name of the driver. Used by Cekit to identify image to be built.
+     */
+    String getName();
+
+    /**
      * @return Name of the driver image.
      */
     String getImageName();
@@ -34,35 +39,19 @@ public interface ExternalDriver {
     String getImageVersion();
 
     /**
-     * @return Driver Docker file path relative to base script folder.
+     * @param dockerUrl URL to Docker registry.
+     * @return Docker tag where the driver image is built using Cekit.
      */
-    String getDockerFileRelativePath();
-
-    /**
-     * @return Install directories for OpenShift build producing Kie server with custom driver.
-     */
-    String getCustomInstallDirectories();
-
-    /**
-     * @return Specify the file or directory to copy from the source image and its destination in the build directory. Format: [source]:[destination-dir].
-     */
-    String getSourceImagePath();
+    String getSourceDockerTag();
 
     /**
      * @param dockerUrl URL to Docker registry.
-     * @return Docker tag.
+     * @return Docker tag where the driver image should be pushed to.
      */
-    String getDockerTag(URL dockerUrl);
+    String getTargetDockerTag(URL dockerUrl);
 
     /**
-     * @param kieJdbcDriverScriptsFolder Folder containing all driver scripts.
-     * @param dockerUrl URL to Docker registry.
-     * @return Docker command to build driver image.
+     * @return Cekit command to build driver image.
      */
-    String getDockerImageBuildCommand(File kieJdbcDriverScriptsFolder, URL dockerUrl);
-
-    /**
-     * @return Location where driver binary file should be downloaded to.
-     */
-    File getDriverBinaryFileLocation();
+    String getCekitImageBuildCommand();
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/MssqlExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/MssqlExternalDriver.java
@@ -18,32 +18,17 @@ package org.kie.cloud.openshift.database.driver;
 public class MssqlExternalDriver extends AbstractExternalDriver {
 
     @Override
+    public String getName() {
+        return "mssql";
+    }
+
+    @Override
     public String getImageName() {
-        return "mssql-driver-image";
+        return "jboss-kie-mssql-extension-openshift-image";
     }
 
     @Override
     public String getImageVersion() {
-        return "2016";
-    }
-
-    @Override
-    public String getDockerFileRelativePath() {
-        return "mssql-driver-image";
-    }
-
-    @Override
-    public String getCustomInstallDirectories() {
-        return "mssql-driver/extensions";
-    }
-
-    @Override
-    public String getSourceImagePath() {
-        return "/extensions:mssql-driver/";
-    }
-
-    @Override
-    protected String getDriverBinaryFileLocationInArtifactRepo() {
-        return "com/microsoft/sqlserver/sqljdbc4/4.0/sqljdbc4-4.0.jar";
+        return "7.2.2.jre11";
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/MySqlExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/MySqlExternalDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,20 @@
 
 package org.kie.cloud.openshift.database.driver;
 
-public class MariaDbExternalDriver extends AbstractExternalDriver {
+public class MySqlExternalDriver extends AbstractExternalDriver {
 
     @Override
     public String getName() {
-        return "mariadb";
+        return "mysql";
     }
 
     @Override
     public String getImageName() {
-        return "jboss-kie-mariadb-extension-openshift-image";
+        return "jboss-kie-mysql-extension-openshift-image";
     }
 
     @Override
     public String getImageVersion() {
-        return "2.4.0";
+        return "8.0.12";
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/OracleExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/OracleExternalDriver.java
@@ -18,6 +18,11 @@ package org.kie.cloud.openshift.database.driver;
 public class OracleExternalDriver extends AbstractExternalDriver {
 
     @Override
+    public String getName() {
+        return "oracle";
+    }
+
+    @Override
     public String getImageName() {
         return "oracle-driver-image";
     }
@@ -25,25 +30,5 @@ public class OracleExternalDriver extends AbstractExternalDriver {
     @Override
     public String getImageVersion() {
         return "12c";
-    }
-
-    @Override
-    public String getDockerFileRelativePath() {
-        return "oracle-driver-image";
-    }
-
-    @Override
-    public String getCustomInstallDirectories() {
-        return "oracle-driver/extensions";
-    }
-
-    @Override
-    public String getSourceImagePath() {
-        return "/extensions:oracle-driver/";
-    }
-
-    @Override
-    protected String getDriverBinaryFileLocationInArtifactRepo() {
-        return "com/oracle/ojdbc7/12.1.0.1/ojdbc7-12.1.0.1.jar";
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/PostgreSqlExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/PostgreSqlExternalDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,20 @@
 
 package org.kie.cloud.openshift.database.driver;
 
-public class MariaDbExternalDriver extends AbstractExternalDriver {
+public class PostgreSqlExternalDriver extends AbstractExternalDriver {
 
     @Override
     public String getName() {
-        return "mariadb";
+        return "postgresql";
     }
 
     @Override
     public String getImageName() {
-        return "jboss-kie-mariadb-extension-openshift-image";
+        return "jboss-kie-postgresql-extension-openshift-image";
     }
 
     @Override
     public String getImageVersion() {
-        return "2.4.0";
+        return "42.2.5";
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/SybaseExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/SybaseExternalDriver.java
@@ -18,6 +18,11 @@ package org.kie.cloud.openshift.database.driver;
 public class SybaseExternalDriver extends AbstractExternalDriver {
 
     @Override
+    public String getName() {
+        return "sybase";
+    }
+
+    @Override
     public String getImageName() {
         return "sybase-driver-image";
     }
@@ -25,25 +30,5 @@ public class SybaseExternalDriver extends AbstractExternalDriver {
     @Override
     public String getImageVersion() {
         return "16.0";
-    }
-
-    @Override
-    public String getDockerFileRelativePath() {
-        return "sybase-driver-image";
-    }
-
-    @Override
-    public String getCustomInstallDirectories() {
-        return "sybase-driver/extensions";
-    }
-
-    @Override
-    public String getSourceImagePath() {
-        return "/extensions:sybase-driver/";
-    }
-
-    @Override
-    protected String getDriverBinaryFileLocationInArtifactRepo() {
-        return "com/sysbase/jconn4/16.0_PL05/jconn4-16.0_PL05.jar";
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractDb2ExternalDatabase.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractDb2ExternalDatabase.java
@@ -16,8 +16,6 @@
 package org.kie.cloud.openshift.database.external;
 
 
-import java.util.Optional;
-
 import org.kie.cloud.openshift.database.driver.Db2ExternalDriver;
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
 
@@ -31,17 +29,7 @@ public abstract class AbstractDb2ExternalDatabase implements ExternalDatabase {
     }
 
     @Override
-    public Optional<ExternalDriver> getExternalDriver() {
-        return Optional.of(driver);
-    }
-
-    @Override
-    public String getDriverImageName() {
-        return "jboss-kie-db2-extension-openshift-image";
-    }
-
-    @Override
-    public String getDriverImageVersion() {
-        return "11.1.4.4";
+    public ExternalDriver getExternalDriver() {
+        return driver;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractMariaDbExternalDatabase.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractMariaDbExternalDatabase.java
@@ -15,8 +15,6 @@
 
 package org.kie.cloud.openshift.database.external;
 
-import java.util.Optional;
-
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
 import org.kie.cloud.openshift.database.driver.MariaDbExternalDriver;
 
@@ -30,17 +28,7 @@ public abstract class AbstractMariaDbExternalDatabase implements ExternalDatabas
     }
 
     @Override
-    public Optional<ExternalDriver> getExternalDriver() {
-        return Optional.of(driver);
-    }
-
-    @Override
-    public String getDriverImageName() {
-        return "jboss-kie-mariadb-extension-openshift-image";
-    }
-
-    @Override
-    public String getDriverImageVersion() {
-        return "2.4.0";
+    public ExternalDriver getExternalDriver() {
+        return driver;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractMssqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractMssqlExternalDatabase.java
@@ -15,8 +15,6 @@
 
 package org.kie.cloud.openshift.database.external;
 
-import java.util.Optional;
-
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
 import org.kie.cloud.openshift.database.driver.MssqlExternalDriver;
 
@@ -30,17 +28,7 @@ public abstract class AbstractMssqlExternalDatabase implements ExternalDatabase 
     }
 
     @Override
-    public Optional<ExternalDriver> getExternalDriver() {
-        return Optional.of(driver);
-    }
-
-    @Override
-    public String getDriverImageName() {
-        return "jboss-kie-mssql-extension-openshift-image";
-    }
-
-    @Override
-    public String getDriverImageVersion() {
-        return "7.0.0.jre8";
+    public ExternalDriver getExternalDriver() {
+        return driver;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractMySqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractMySqlExternalDatabase.java
@@ -15,11 +15,12 @@
 
 package org.kie.cloud.openshift.database.external;
 
-import java.util.Optional;
-
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
+import org.kie.cloud.openshift.database.driver.MySqlExternalDriver;
 
 public abstract class AbstractMySqlExternalDatabase implements ExternalDatabase {
+
+    private ExternalDriver driver = new MySqlExternalDriver();
 
     @Override
     public String getDriverName() {
@@ -27,17 +28,7 @@ public abstract class AbstractMySqlExternalDatabase implements ExternalDatabase 
     }
 
     @Override
-    public Optional<ExternalDriver> getExternalDriver() {
-        return Optional.empty();
-    }
-
-    @Override
-    public String getDriverImageName() {
-        return "jboss-kie-mysql-extension-openshift-image";
-    }
-
-    @Override
-    public String getDriverImageVersion() {
-        return "8.0.12";
+    public ExternalDriver getExternalDriver() {
+        return driver;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractOracleExternalDatabase.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractOracleExternalDatabase.java
@@ -15,8 +15,6 @@
 
 package org.kie.cloud.openshift.database.external;
 
-import java.util.Optional;
-
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
 import org.kie.cloud.openshift.database.driver.OracleExternalDriver;
 
@@ -30,19 +28,7 @@ public abstract class AbstractOracleExternalDatabase implements ExternalDatabase
     }
 
     @Override
-    public Optional<ExternalDriver> getExternalDriver() {
-        return Optional.of(driver);
-    }
-
-    @Override
-    public String getDriverImageName() {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public String getDriverImageVersion() {
-        // TODO Auto-generated method stub
-        return null;
+    public ExternalDriver getExternalDriver() {
+        return driver;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractPostgreSqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractPostgreSqlExternalDatabase.java
@@ -15,11 +15,12 @@
 
 package org.kie.cloud.openshift.database.external;
 
-import java.util.Optional;
-
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
+import org.kie.cloud.openshift.database.driver.PostgreSqlExternalDriver;
 
 public abstract class AbstractPostgreSqlExternalDatabase implements ExternalDatabase {
+
+    private ExternalDriver driver = new PostgreSqlExternalDriver();
 
     @Override
     public String getDriverName() {
@@ -27,17 +28,7 @@ public abstract class AbstractPostgreSqlExternalDatabase implements ExternalData
     }
 
     @Override
-    public Optional<ExternalDriver> getExternalDriver() {
-        return Optional.empty();
-    }
-
-    @Override
-    public String getDriverImageName() {
-        return "jboss-kie-postgresql-extension-openshift-image";
-    }
-
-    @Override
-    public String getDriverImageVersion() {
-        return "42.2.5";
+    public ExternalDriver getExternalDriver() {
+        return driver;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractSybaseExternalDatabase.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/AbstractSybaseExternalDatabase.java
@@ -15,8 +15,6 @@
 
 package org.kie.cloud.openshift.database.external;
 
-import java.util.Optional;
-
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
 import org.kie.cloud.openshift.database.driver.SybaseExternalDriver;
 
@@ -30,19 +28,7 @@ public abstract class AbstractSybaseExternalDatabase implements ExternalDatabase
     }
 
     @Override
-    public Optional<ExternalDriver> getExternalDriver() {
-        return Optional.of(driver);
-    }
-
-    @Override
-    public String getDriverImageName() {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public String getDriverImageVersion() {
-        // TODO Auto-generated method stub
-        return null;
+    public ExternalDriver getExternalDriver() {
+        return driver;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/ExternalDatabase.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/ExternalDatabase.java
@@ -16,7 +16,6 @@
 package org.kie.cloud.openshift.database.external;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
 
@@ -26,27 +25,17 @@ import org.kie.cloud.openshift.database.driver.ExternalDriver;
 public interface ExternalDatabase {
 
     /**
-     * @return Name of the database driver. Needs to be aligned to database property for datasource based timer service.
+     * @return Name of the database driver. It is used by EAP to use correct EJB database initialization scripts.
      */
     String getDriverName();
 
     /**
-     * @return Custom external driver if required, otherwise empty.
+     * @return Custom external driver.
      */
-    Optional<ExternalDriver> getExternalDriver();
+    ExternalDriver getExternalDriver();
 
     /**
      * @return All environment variables required for connection to this database.
      */
     Map<String, String> getExternalDatabaseEnvironmentVariables();
-
-    /**
-     * @return Image name of driver image.
-     */
-    String getDriverImageName();
-
-    /**
-     * @return Image version of driver image.
-     */
-    String getDriverImageVersion();
 }


### PR DESCRIPTION
There is no need to set external.registry.url any more, however kie.jdbc.driver.scripts is required.
Please install Cekit locally to run tests with external DBs (see doc for instructions how).

APB adjustments were done to make module compile and moreless same as for templates. APB will probably not run correctly.