### PR TITLE
Replace Kie Operator OC binary calls with Fabric8 client calls

### DIFF
--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/OpenShiftController.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/OpenShiftController.java
@@ -48,6 +48,21 @@ public class OpenShiftController {
     }
 
     /**
+     * @return OpenShift admin with project namespace configured.
+     */
+    public static OpenShift getOpenShiftAdmin() {
+        return getOpenShiftAdmin(OpenShiftConfig.namespace());
+    }
+
+    /**
+     * @param projectName Namespace to be set to OpenShift.
+     * @return OpenShift admin with project namespace configured.
+     */
+    public static OpenShift getOpenShiftAdmin(String projectName) {
+        return OpenShifts.admin(projectName);
+    }
+
+    /**
      * @param projectName Project name.
      * @return Project object representing created project.
      */

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
@@ -44,6 +44,11 @@ public interface Project extends AutoCloseable {
     public OpenShift getOpenShift();
 
     /**
+     * @return OpenShift admin client.
+     */
+    public OpenShift getOpenShiftAdmin();
+
+    /**
      * Process template and create all resources defined there.
      *
      * @param templateUrl URL of template to be processed

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
@@ -56,10 +56,12 @@ public class ProjectImpl implements Project {
 
     private String projectName;
     private OpenShift openShift;
+    private OpenShift openShiftAdmin;
 
     public ProjectImpl(String projectName) {
         this.projectName = projectName;
         this.openShift = OpenShiftController.getOpenShift(projectName);
+        this.openShiftAdmin = OpenShiftController.getOpenShiftAdmin(projectName);
     }
 
     @Override
@@ -67,8 +69,14 @@ public class ProjectImpl implements Project {
         return projectName;
     }
 
+    @Override
     public OpenShift getOpenShift() {
         return openShift;
+    }
+
+    @Override
+    public OpenShift getOpenShiftAdmin() {
+        return openShiftAdmin;
     }
 
     @Override


### PR DESCRIPTION
Used to reduce possibility of error caused by multiple tests using one OC binary.
The OC binary is shared resource, should be ideally used just by one thread at the time.