### PR TITLE
Cherry-pick 7.23.x: Correct logs many containers (#427)

### DIFF
--- a/framework-cloud/framework-cloud-common/src/main/java/org/kie/cloud/common/logs/InstanceLogUtil.java
+++ b/framework-cloud/framework-cloud-common/src/main/java/org/kie/cloud/common/logs/InstanceLogUtil.java
@@ -17,12 +17,9 @@ package org.kie.cloud.common.logs;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.List;
 
 import org.apache.commons.io.FileUtils;
-import org.kie.cloud.api.deployment.Deployment;
 import org.kie.cloud.api.deployment.Instance;
-import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,26 +32,19 @@ public class InstanceLogUtil {
     private static final String LOG_SUFFIX = ".log";
 
     public static void writeInstanceLogs(Instance instance, String customLogFolderName) {
-        File logFile = getOutputFile(instance.getName(), customLogFolderName);
+        writeInstanceLogs(instance.getName(), customLogFolderName, instance.getLogs());
+    }
+
+    public static void writeInstanceLogs(String name, String customLogFolderName, String logs) {
+        File logFile = getOutputFile(name, customLogFolderName);
         try {
-            FileUtils.write(logFile, instance.getLogs(), "UTF-8");
+            FileUtils.write(logFile, logs, "UTF-8");
         } catch (Exception e) {
             logger.error("Error writting instance logs", e);
         }
     }
 
-    public static void writeDeploymentLogs(DeploymentScenario<?> deploymentScenario) {
-        for (Deployment deployment : deploymentScenario.getDeployments()) {
-            if (deployment != null) {
-                List<Instance> instances = deployment.getInstances();
-                for (Instance instance : instances) {
-                    writeInstanceLogs(instance, deploymentScenario.getLogFolderName());
-                }
-            }
-        }
-    }
-
-    public static void appendInstanceLogLines(String instanceName, Collection<String> lines, String customLogFolderName) {
+    public static void appendInstanceLogLines(String instanceName, String customLogFolderName, Collection<String> lines) {
         File logFile = getOutputFile(instanceName, customLogFolderName);
         try {
             FileUtils.writeLines(logFile, "UTF-8", lines, true);

--- a/framework-cloud/framework-openshift/pom.xml
+++ b/framework-cloud/framework-openshift/pom.xml
@@ -36,6 +36,10 @@
       <groupId>io.reactivex</groupId>
       <artifactId>rxjava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava-string</artifactId>
+    </dependency>
 
     <!-- RH SSO dependencies  -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -40,6 +40,7 @@
 
     <version.cz.xtf>0.12</version.cz.xtf>
     <version.rx-java>1.3.0</version.rx-java> <!-- rxjava dependency version depends on version.cz.xtf used -->
+    <version.rx-java-string>1.1.1</version.rx-java-string> <!-- rxjava-string dependency version depends on version.cz.xtf used -->
     <version.org.keycloak>4.8.3.Final</version.org.keycloak>
     <version.org.projectlombok>1.16.10</version.org.projectlombok>
     <version.org.jboss.jboss-dmr>1.5.0.Final</version.org.jboss.jboss-dmr>
@@ -49,7 +50,8 @@
   </properties>
 
   <repositories>
-    <!-- Bootstrap repository to locate the parent pom when the parent pom has not been build locally. -->
+    <!-- Bootstrap repository to locate the parent pom when the parent pom 
+      has not been build locally. -->
     <repository>
       <id>jboss-public-repository-group</id>
       <name>JBoss Public Repository Group</name>
@@ -118,7 +120,7 @@
         <artifactId>framework-git</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
-     <dependency>
+      <dependency>
         <groupId>org.kie.cloud</groupId>
         <artifactId>framework-maven</artifactId>
         <version>${version.org.kie}</version>
@@ -223,6 +225,11 @@
         <groupId>io.reactivex</groupId>
         <artifactId>rxjava</artifactId>
         <version>${version.rx-java}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.reactivex</groupId>
+        <artifactId>rxjava-string</artifactId>
+        <version>${version.rx-java-string}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
* Allow to log all containers of a pod

- Correct a design problem on Fabric8 Openshift client (creating bug)
- Added test on flush instance

* added a dep in pom to avoid transitive dependencies