### PR TITLE
Extend Kie server route timeout to 3 minutes

### DIFF
--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/TimerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/TimerIntegrationTest.java
@@ -38,6 +38,7 @@ import org.kie.cloud.tests.common.time.Constants;
 import org.kie.cloud.tests.common.time.TimeUtils;
 import org.kie.cloud.integrationtests.category.ApbNotSupported;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
+import org.kie.cloud.integrationtests.category.OperatorNotSupported;
 import org.kie.cloud.maven.MavenDeployer;
 import org.kie.cloud.maven.constants.MavenConstants;
 import org.kie.server.api.model.KieContainerStatus;
@@ -48,7 +49,7 @@ import org.kie.server.client.QueryServicesClient;
 import org.kie.server.controller.client.KieServerControllerClient;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
-@Category({ApbNotSupported.class, JBPMOnly.class}) // Because TimerServiceDataStoreRefreshInterval is not supported yet
+@Category({ApbNotSupported.class, OperatorNotSupported.class, JBPMOnly.class}) // Because TimerServiceDataStoreRefreshInterval is not supported yet, Operator is skipped as scenario use different startup strategy than template.
 public class TimerIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario> {
 
     private static final Kjar DEPLOYED_KJAR = Kjar.TIMER;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
@@ -15,6 +15,8 @@
  */
 package org.kie.cloud.integrationtests.ldap;
 
+import java.time.Duration;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -85,6 +87,7 @@ public class WorkbenchKieServerPersistentScenarioLdapIntegrationTest extends Abs
         KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
 
+        deploymentScenario.getKieServerDeployment().setRouterTimeout(Duration.ofMinutes(3));
         deploymentScenario.getKieServerDeployment().scale(0);
         deploymentScenario.getKieServerDeployment().waitForScale();
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
@@ -15,6 +15,8 @@
 
 package org.kie.cloud.integrationtests.smoke;
 
+import java.time.Duration;
+
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -69,6 +71,7 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTes
         KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
 
+        deploymentScenario.getKieServerDeployment().setRouterTimeout(Duration.ofMinutes(3));
         deploymentScenario.getKieServerDeployment().scale(0);
         deploymentScenario.getKieServerDeployment().waitForScale();
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest.java
@@ -15,6 +15,8 @@
 
 package org.kie.cloud.integrationtests.smoke;
 
+import java.time.Duration;
+
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -68,6 +70,7 @@ public class ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest extend
         KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
 
+        deploymentScenario.getKieServerDeployment().setRouterTimeout(Duration.ofMinutes(3));
         deploymentScenario.getKieServerDeployment().scale(0);
         deploymentScenario.getKieServerDeployment().waitForScale();
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioIntegrationTest.java
@@ -15,6 +15,8 @@
 
 package org.kie.cloud.integrationtests.smoke;
 
+import java.time.Duration;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -67,6 +69,7 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
             KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(kieServerDeployment);
             KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
 
+            kieServerDeployment.setRouterTimeout(Duration.ofMinutes(3));
             kieServerDeployment.scale(0);
             kieServerDeployment.waitForScale();
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
@@ -64,6 +64,7 @@ public class WorkbenchKieServerPersistentScenarioIntegrationTest extends Abstrac
         KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
 
+        deploymentScenario.getKieServerDeployment().setRouterTimeout(Duration.ofMinutes(3));
         deploymentScenario.getKieServerDeployment().scale(0);
         deploymentScenario.getKieServerDeployment().waitForScale();
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerScenarioIntegrationTest.java
@@ -63,6 +63,7 @@ public class WorkbenchKieServerScenarioIntegrationTest extends AbstractCloudInte
         KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
 
+        deploymentScenario.getKieServerDeployment().setRouterTimeout(Duration.ofMinutes(3));
         deploymentScenario.getKieServerDeployment().scale(0);
         deploymentScenario.getKieServerDeployment().waitForScale();
 


### PR DESCRIPTION
Related to Optaplanner test, this test requires more time to deploy
Kie server container due to kjar dependencies.