### PR TITLE
[7.30.x] Add possibility to retrieve Maven repository from scenario

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/DeploymentScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/DeploymentScenario.java
@@ -16,9 +16,11 @@ package org.kie.cloud.api.scenario;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.kie.cloud.api.deployment.Deployment;
 import org.kie.cloud.api.deployment.DeploymentTimeoutException;
+import org.kie.cloud.api.deployment.MavenRepositoryDeployment;
 
 public interface DeploymentScenario<T extends DeploymentScenario<T>> {
     /**
@@ -71,9 +73,9 @@ public interface DeploymentScenario<T extends DeploymentScenario<T>> {
     void addDeploymentScenarioListener(DeploymentScenarioListener<T> deploymentScenarioListener);
 
     /**
-     * Return the environment for the scenario
-     * 
-     * @return Map of key/value
+     * Return external Maven repository deployment.
+     *
+     * @return External Maven repository deployment.
      */
-    Map<String, String> getScenarioEnvironment();
+    MavenRepositoryDeployment getMavenRepositoryDeployment();
 }

--- a/framework-cloud/framework-maven/src/main/java/org/kie/cloud/maven/util/MavenUtil.java
+++ b/framework-cloud/framework-maven/src/main/java/org/kie/cloud/maven/util/MavenUtil.java
@@ -93,4 +93,9 @@ public class MavenUtil {
         this.maven.setEnvironmentVariable(key, value);
         return this;
     }
+
+    public MavenUtil setSystemProperty(String key, String value) {
+        maven.setSystemProperty(key, value);
+        return this;
+    }
 }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioApb.java
@@ -249,8 +249,4 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
     public SsoDeployment getSsoDeployment() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
-
-    public Map<String, String> getScenarioEnvironment() {
-        return new HashMap<>(extraVars);
-    }
 }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioApb.java
@@ -164,8 +164,4 @@ public class KieServerWithExternalDatabaseScenarioApb extends OpenShiftScenario<
                 DeploymentConstants.getCustomTrustedKeystoreAlias());
         extraVars.put(OpenShiftApbConstants.KIESERVER_KEYSTORE_PWD, DeploymentConstants.getCustomTrustedKeystorePwd());
     }
-
-    public Map<String, String> getScenarioEnvironment() {
-        return new HashMap<>(extraVars);
-    }
 }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerPersistentScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerPersistentScenarioApb.java
@@ -183,8 +183,4 @@ public class WorkbenchKieServerPersistentScenarioApb extends OpenShiftScenario<W
     public List<ControllerDeployment> getControllerDeployments() {
         return Collections.emptyList();
     }
-
-    public Map<String, String> getScenarioEnvironment() {
-        return new HashMap<>(extraVars);
-    }
 }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioApb.java
@@ -174,8 +174,4 @@ public class WorkbenchKieServerScenarioApb extends OpenShiftScenario<WorkbenchKi
     public Optional<PrometheusDeployment> getPrometheusDeployment() {
         return Optional.ofNullable(prometheusDeployment);
     }
-
-    public Map<String, String> getScenarioEnvironment() {
-        return new HashMap<>(extraVars);
-    }
 }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioApb.java
@@ -218,9 +218,4 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScena
 
         return deployment;
     }
-
-    @Override
-    public Map<String, String> getScenarioEnvironment() {
-        return new HashMap<>(extraVars);
-    }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/external/AbstractExternalDeployment.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/external/AbstractExternalDeployment.java
@@ -40,7 +40,8 @@ public abstract class AbstractExternalDeployment<T extends Deployment, U> implem
 
     protected abstract T deployToProject(Project project);
 
-    protected T getDeploymentInformation() {
+    @Override
+    public T getDeploymentInformation() {
         if (Objects.isNull(this.deployment)) {
             throw new RuntimeException("Trying to access deployment informaiton whereas the deployment has not been done ...");
         }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/external/ExternalDeployment.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/external/ExternalDeployment.java
@@ -40,6 +40,11 @@ public interface ExternalDeployment<T extends Deployment, U> {
     T deploy(Project project);
 
     /**
+     * @return Deployment entity of this external deployment
+     */
+    T getDeploymentInformation();
+
+    /**
      * Configure the given object with this external deployment information
      * 
      * @param object This object should be specific for deployment process (templates, operator, apb ...)

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/api/deployment/KjarDeployer.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/api/deployment/KjarDeployer.java
@@ -34,10 +34,10 @@ public class KjarDeployer {
         return new KjarDeployer(kjar);
     }
 
-    public void deploy(Map<String, String> deploymentEnvironment) {
+    public void deploy(MavenRepositoryDeployment repositoryDeployment) {
         // Synchronize on kjar deployment to avoid conflicts
         synchronized (kjar) {
-            MavenDeployer.buildAndDeployMavenProject(KjarDeployer.class.getResource(KJAR_SOURCES_FOLDER + kjar.getProjectName()).getFile(), deploymentEnvironment);
+            MavenDeployer.buildAndDeployMavenProject(KjarDeployer.class.getResource(KJAR_SOURCES_FOLDER + kjar.getProjectName()).getFile(), repositoryDeployment);
         }
     }
 }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/api/scenario/KjarDeploymentScenarioListener.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/api/scenario/KjarDeploymentScenarioListener.java
@@ -36,7 +36,7 @@ public class KjarDeploymentScenarioListener<T extends DeploymentScenario<T>> imp
 
     @Override
     public void beforeDeploymentStarted(T deploymentScenario) {
-        this.kjars.forEach(kjar -> KjarDeployer.create(kjar).deploy(deploymentScenario.getScenarioEnvironment()));
+        this.kjars.forEach(kjar -> KjarDeployer.create(kjar).deploy(deploymentScenario.getMavenRepositoryDeployment()));
     }
 
     @Override

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/drools/DroolsSessionFailoverIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/drools/DroolsSessionFailoverIntegrationTest.java
@@ -79,7 +79,7 @@ public class DroolsSessionFailoverIntegrationTest extends AbstractMethodIsolated
 
     @Before
     public void setUp() {
-        KjarDeployer.create(Kjar.RULE_SNAPSHOT).deploy(deploymentScenario.getScenarioEnvironment());
+        KjarDeployer.create(Kjar.RULE_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
 
         kieServerControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchRuntimeDeployment());
         smartRouterServicesClient = KieServerClientProvider.getSmartRouterClient(deploymentScenario.getSmartRouterDeployment(), deploymentScenario.getKieServerOneDeployment().getUsername(), deploymentScenario

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/TimerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/jbpm/TimerIntegrationTest.java
@@ -66,7 +66,7 @@ public class TimerIntegrationTest extends AbstractMethodIsolatedCloudIntegration
 
     @Before
     public void setUp() {
-        KjarDeployer.create(DEPLOYED_KJAR).deploy(deploymentScenario.getScenarioEnvironment());
+        KjarDeployer.create(DEPLOYED_KJAR).deploy(deploymentScenario.getMavenRepositoryDeployment());
 
         kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchRuntimeDeployment());
     }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
@@ -70,10 +70,10 @@ public class ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest ex
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
         projectBuilderTestProvider = ProjectBuilderTestProvider.create();
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
     }
 
     @AfterClass

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioLdapIntegrationTest.java
@@ -69,10 +69,10 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         httpsWorkbenchTestProvider = HttpsWorkbenchTestProvider.create();
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithMySqlLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithMySqlLdapIntegrationTest.java
@@ -67,10 +67,10 @@ public class KieServerWithMySqlLdapIntegrationTest extends AbstractCloudIntegrat
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
     }
 
     @AfterClass

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithPostgreSqlLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithPostgreSqlLdapIntegrationTest.java
@@ -68,10 +68,10 @@ public class KieServerWithPostgreSqlLdapIntegrationTest extends AbstractCloudInt
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
     }
 
     @AfterClass

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
@@ -89,10 +89,10 @@ public class WorkbenchKieServerPersistentScenarioLdapIntegrationTest extends Abs
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         httpsWorkbenchTestProvider = HttpsWorkbenchTestProvider.create();
         persistenceTestProvider = PersistenceTestProvider.create();
         projectBuilderTestProvider = ProjectBuilderTestProvider.create();

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
@@ -145,7 +145,7 @@ public class KieServerS2iWithLdapDroolsIntegrationTest extends AbstractMethodIso
     @BeforeClass
     public static void buildKjar() {
         MavenDeployer.buildAndInstallMavenProject(
-                KieServerS2iWithLdapDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile(), new HashMap<>());
+                KieServerS2iWithLdapDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
@@ -128,7 +128,7 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndInstallMavenProject(KieServerS2iDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile(), new HashMap<>());
+        MavenDeployer.buildAndInstallMavenProject(KieServerS2iDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
@@ -122,7 +122,7 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
     @BeforeClass
     public static void buildKjar() {
         MavenDeployer.buildAndInstallMavenProject(
-                KieServerS2iOptaplannerIntegrationTest.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile(), new HashMap<>());
+                KieServerS2iOptaplannerIntegrationTest.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqDroolsIntegrationTest.java
@@ -18,7 +18,6 @@ package org.kie.cloud.integrationtests.s2i.jms;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -129,7 +128,7 @@ public class KieServerS2iAmqDroolsIntegrationTest extends AbstractMethodIsolated
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndInstallMavenProject(KieServerS2iAmqDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile(), new HashMap<>());
+        MavenDeployer.buildAndInstallMavenProject(KieServerS2iAmqDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqOptaplannerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqOptaplannerIntegrationTest.java
@@ -124,7 +124,7 @@ public class KieServerS2iAmqOptaplannerIntegrationTest extends AbstractMethodIso
     @BeforeClass
     public static void buildKjar() {
         MavenDeployer.buildAndInstallMavenProject(
-            KieServerS2iAmqOptaplannerIntegrationTest.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile(), new HashMap<>());
+            KieServerS2iAmqOptaplannerIntegrationTest.class.getResource("/kjars-sources/cloudbalance-snapshot").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWebSocketScalingIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWebSocketScalingIntegrationTest.java
@@ -85,7 +85,7 @@ public class KieServerWebSocketScalingIntegrationTest {
             Assume.assumeNoException(e);
         }
 
-        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getScenarioEnvironment());
+        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
 
         kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerOneDeployment());
         kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchRuntimeDeployment());

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWithSmartRouterHttpScalingIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/scaling/KieServerWithSmartRouterHttpScalingIntegrationTest.java
@@ -67,7 +67,7 @@ public class KieServerWithSmartRouterHttpScalingIntegrationTest extends Abstract
 
     @Before
     public void setUp() {
-        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getScenarioEnvironment());
+        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
 
         kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchRuntimeDeployment());
         kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerOneDeployment());

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
@@ -70,10 +70,10 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTes
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         httpsWorkbenchTestProvider = HttpsWorkbenchTestProvider.create();
 
         // Workaround to speed test execution.

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest.java
@@ -69,10 +69,10 @@ public class ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest extend
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         httpsWorkbenchTestProvider = HttpsWorkbenchTestProvider.create();
 
         // Workaround to speed test execution.

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
@@ -69,10 +69,10 @@ public class ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrat
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         httpsWorkbenchTestProvider = HttpsWorkbenchTestProvider.create();
 
         // Workaround to speed test execution.

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioIntegrationTest.java
@@ -69,12 +69,12 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         httpsWorkbenchTestProvider = HttpsWorkbenchTestProvider.create();
-        smartRouterTestProvider = SmartRouterTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        smartRouterTestProvider = SmartRouterTestProvider.create(deploymentScenario);
 
         // Workaround to speed test execution.
         // Create all containers while Kie servers are turned off to avoid expensive respins.

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerScenarioIntegrationTest.java
@@ -50,9 +50,9 @@ public class KieServerScenarioIntegrationTest extends AbstractCloudIntegrationTe
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
     }
 
     @AfterClass

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithExternalDatabaseIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithExternalDatabaseIntegrationTest.java
@@ -57,10 +57,10 @@ public class KieServerWithExternalDatabaseIntegrationTest extends AbstractCloudI
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
     }
 
     @AfterClass

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithMySqlScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithMySqlScenarioIntegrationTest.java
@@ -53,10 +53,10 @@ public class KieServerWithMySqlScenarioIntegrationTest extends AbstractCloudInte
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
     }
 
     @AfterClass

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithPostgreSqlScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithPostgreSqlScenarioIntegrationTest.java
@@ -50,10 +50,10 @@ public class KieServerWithPostgreSqlScenarioIntegrationTest extends AbstractClou
             ScenarioDeployer.deployScenario(deploymentScenario);
 
             // Setup test providers
-            fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-            processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-            optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-            httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+            fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+            processTestProvider = ProcessTestProvider.create(deploymentScenario);
+            optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+            httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         } catch (UnsupportedOperationException ex) {
             Assume.assumeFalse(ex.getMessage().startsWith("Not supported"));
         }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
@@ -64,10 +64,10 @@ public class WorkbenchKieServerPersistentScenarioIntegrationTest extends Abstrac
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         httpsWorkbenchTestProvider = HttpsWorkbenchTestProvider.create();
 
         // Workaround to speed test execution.

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerScenarioIntegrationTest.java
@@ -60,9 +60,9 @@ public class WorkbenchKieServerScenarioIntegrationTest extends AbstractCloudInte
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
 
         // Workaround to speed test execution.
         // Create all containers while Kie servers are turned off to avoid expensive respins.

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
@@ -78,9 +78,9 @@ public class ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest ext
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
         projectBuilderTestProvider = ProjectBuilderTestProvider.create();
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioSsoIntegrationTest.java
@@ -78,10 +78,10 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         httpsWorkbenchTestProvider = HttpsWorkbenchTestProvider.create();
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/KieServerWithMySqlSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/KieServerWithMySqlSsoIntegrationTest.java
@@ -62,10 +62,10 @@ public class KieServerWithMySqlSsoIntegrationTest extends AbstractCloudIntegrati
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
     }
 
     @AfterClass

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/KieServerWithPostgreSqlSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/KieServerWithPostgreSqlSsoIntegrationTest.java
@@ -62,10 +62,10 @@ public class KieServerWithPostgreSqlSsoIntegrationTest extends AbstractCloudInte
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
     }
 
     @AfterClass

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/WorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/WorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
@@ -65,10 +65,10 @@ public class WorkbenchKieServerPersistentScenarioSsoIntegrationTest extends Abst
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
-        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        processTestProvider = ProcessTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario.getScenarioEnvironment());
-        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario.getScenarioEnvironment());
+        fireRulesTestProvider = FireRulesTestProvider.create(deploymentScenario);
+        processTestProvider = ProcessTestProvider.create(deploymentScenario);
+        optaplannerTestProvider = OptaplannerTestProvider.create(deploymentScenario);
+        httpsKieServerTestProvider = HttpsKieServerTestProvider.create(deploymentScenario);
         httpsWorkbenchTestProvider = HttpsWorkbenchTestProvider.create();
         persistenceTestProvider = PersistenceTestProvider.create();
         projectBuilderTestProvider = ProjectBuilderTestProvider.create();

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/s2i/KieServerS2iWithSsoDroolsIntegrationTest.java
@@ -18,7 +18,6 @@ package org.kie.cloud.integrationtests.sso.s2i;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -140,7 +139,7 @@ public class KieServerS2iWithSsoDroolsIntegrationTest extends AbstractMethodIsol
 
     @BeforeClass
     public static void buildKjar() {
-        MavenDeployer.buildAndInstallMavenProject(KieServerS2iWithSsoDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile(), new HashMap<>());
+        MavenDeployer.buildAndInstallMavenProject(KieServerS2iWithSsoDroolsIntegrationTest.class.getResource("/kjars-sources/stateless-session").getFile());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/DbSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/DbSurvivalIntegrationTest.java
@@ -96,7 +96,7 @@ public class DbSurvivalIntegrationTest extends AbstractMethodIsolatedCloudIntegr
 
     @Before
     public void setUp() {
-        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getScenarioEnvironment());
+        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
 
         kieServicesClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
         processServicesClient = KieServerClientProvider.getProcessClient(deploymentScenario.getKieServerDeployment());

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.java
@@ -82,7 +82,7 @@ public class KieServerWithSmartRouterAndControllerSurvivalIntegrationTest extend
         deploymentScenario.setLogFolderName(KieServerWithSmartRouterAndControllerSurvivalIntegrationTest.class.getSimpleName());
         ScenarioDeployer.deployScenario(deploymentScenario);
 
-        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getScenarioEnvironment());
+        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
     }
 
     @Before

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/FireRulesTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/FireRulesTestProvider.java
@@ -18,7 +18,6 @@ package org.kie.cloud.integrationtests.testproviders;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.kie.api.KieServices;
@@ -29,6 +28,7 @@ import org.kie.api.runtime.ExecutionResults;
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.KjarDeployer;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
+import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.git.GitProvider;
@@ -75,16 +75,16 @@ public class FireRulesTestProvider {
      * 
      * @return provider instance
      */
-    public static FireRulesTestProvider create(Map<String, String> environment) {
+    public static FireRulesTestProvider create(DeploymentScenario<?> deploymentScenario) {
         FireRulesTestProvider provider = new FireRulesTestProvider();
-        if (Objects.nonNull(environment)) {
-            provider.init(environment);
+        if (Objects.nonNull(deploymentScenario)) {
+            provider.init(deploymentScenario);
         }
         return provider;
     }
 
-    private void init(Map<String, String> environment) {
-        KjarDeployer.create(Kjar.HELLO_RULES_SNAPSHOT).deploy(environment);
+    private void init(DeploymentScenario<?> deploymentScenario) {
+        KjarDeployer.create(Kjar.HELLO_RULES_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
     }
 
     public void testDeployFromKieServerAndFireRules(KieServerDeployment kieServerDeployment) {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/HttpsKieServerTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/HttpsKieServerTestProvider.java
@@ -31,6 +31,7 @@ import org.apache.http.entity.ContentType;
 import org.assertj.core.api.Assertions;
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.KjarDeployer;
+import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.marshalling.Marshaller;
@@ -74,16 +75,16 @@ public class HttpsKieServerTestProvider {
      * 
      * @return provider instance
      */
-    public static HttpsKieServerTestProvider create(Map<String, String> environment) {
+    public static HttpsKieServerTestProvider create(DeploymentScenario<?> deploymentScenario) {
         HttpsKieServerTestProvider provider = new HttpsKieServerTestProvider();
-        if (Objects.nonNull(environment)) {
-            provider.init(environment);
+        if (Objects.nonNull(deploymentScenario)) {
+            provider.init(deploymentScenario);
         }
         return provider;
     }
 
-    private void init(Map<String, String> environment) {
-        KjarDeployer.create(Kjar.HELLO_RULES_SNAPSHOT).deploy(environment);
+    private void init(DeploymentScenario<?> deploymentScenario) {
+        KjarDeployer.create(Kjar.HELLO_RULES_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
     }
 
     public void testKieServerInfo(KieServerDeployment kieServerDeployment, boolean ssoScenario) {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/HttpsWorkbenchTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/HttpsWorkbenchTestProvider.java
@@ -33,6 +33,7 @@ import cz.xtf.client.HttpResponseParser;
 import org.apache.http.entity.ContentType;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,15 +70,15 @@ public class HttpsWorkbenchTestProvider {
      * 
      * @return provider instance
      */
-    public static HttpsWorkbenchTestProvider create(Map<String, String> environment) {
+    public static HttpsWorkbenchTestProvider create(DeploymentScenario<?> deploymentScenario) {
         HttpsWorkbenchTestProvider provider = new HttpsWorkbenchTestProvider();
-        if (Objects.nonNull(environment)) {
-            provider.init(environment);
+        if (Objects.nonNull(deploymentScenario)) {
+            provider.init(deploymentScenario);
         }
         return provider;
     }
 
-    private void init(Map<String, String> environment) {}
+    private void init(DeploymentScenario<?> deploymentScenario) {}
 
     public void testLoginScreen(WorkbenchDeployment workbenchDeployment, boolean ssoScenario) {
         final URL url = workbenchDeployment.getSecureUrl().get();

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/OptaplannerTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/OptaplannerTestProvider.java
@@ -18,7 +18,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -27,6 +26,7 @@ import org.kie.api.KieServices;
 import org.kie.api.runtime.KieContainer;
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.KjarDeployer;
+import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.tests.common.client.util.KieServerUtils;
 import org.kie.cloud.tests.common.client.util.Kjar;
@@ -69,16 +69,16 @@ public class OptaplannerTestProvider {
      * 
      * @return provider instance
      */
-    public static OptaplannerTestProvider create(Map<String, String> environment) {
+    public static OptaplannerTestProvider create(DeploymentScenario<?> deploymentScenario) {
         OptaplannerTestProvider provider = new OptaplannerTestProvider();
-        if (Objects.nonNull(environment)) {
-            provider.init(environment);
+        if (Objects.nonNull(deploymentScenario)) {
+            provider.init(deploymentScenario);
         }
         return provider;
     }
 
-    private void init(Map<String, String> environment) {
-        KjarDeployer.create(Kjar.CLOUD_BALANCE_SNAPSHOT).deploy(environment);
+    private void init(DeploymentScenario<?> deploymentScenario) {
+        KjarDeployer.create(Kjar.CLOUD_BALANCE_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
     }
 
     public void testDeployFromKieServerAndExecuteSolver(KieServerDeployment kieServerDeployment) {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/PersistenceTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/PersistenceTestProvider.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.kie.cloud.api.deployment.Deployment;
+import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
@@ -53,15 +54,15 @@ public class PersistenceTestProvider {
      * 
      * @return provider instance
      */
-    public static PersistenceTestProvider create(Map<String, String> environment) {
+    public static PersistenceTestProvider create(DeploymentScenario<?> deploymentScenario) {
         PersistenceTestProvider provider = new PersistenceTestProvider();
-        if (Objects.nonNull(environment)) {
-            provider.init(environment);
+        if (Objects.nonNull(deploymentScenario)) {
+            provider.init(deploymentScenario);
         }
         return provider;
     }
 
-    private void init(Map<String, String> environment) {}
+    private void init(DeploymentScenario<?> deploymentScenario) {}
 
     public void testControllerPersistence(WorkbenchKieServerScenario deploymentScenario) {
         String containerId = "testControllerPersistence";

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/ProcessTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/ProcessTestProvider.java
@@ -15,12 +15,12 @@
 package org.kie.cloud.integrationtests.testproviders;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.KjarDeployer;
 import org.kie.cloud.api.deployment.SmartRouterDeployment;
+import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.time.Constants;
@@ -59,16 +59,16 @@ public class ProcessTestProvider {
      * 
      * @return provider instance
      */
-    public static ProcessTestProvider create(Map<String, String> environment) {
+    public static ProcessTestProvider create(DeploymentScenario<?> deploymentScenario) {
         ProcessTestProvider provider = new ProcessTestProvider();
-        if (Objects.nonNull(environment)) {
-            provider.init(environment);
+        if (Objects.nonNull(deploymentScenario)) {
+            provider.init(deploymentScenario);
         }
         return provider;
     }
 
-    private void init(Map<String, String> environment) {
-        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(environment);
+    private void init(DeploymentScenario<?> deploymentScenario) {
+        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
     }
 
     public void testDeployFromKieServerAndExecuteProcesses(KieServerDeployment kieServerDeployment) {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/ProjectBuilderTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/ProjectBuilderTestProvider.java
@@ -14,11 +14,11 @@
  */
 package org.kie.cloud.integrationtests.testproviders;
 
-import java.util.Map;
 import java.util.Objects;
 
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
+import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
 import org.kie.server.api.model.KieContainerResource;
@@ -48,15 +48,15 @@ public class ProjectBuilderTestProvider {
      * 
      * @return provider instance
      */
-    public static ProjectBuilderTestProvider create(Map<String, String> environment) {
+    public static ProjectBuilderTestProvider create(DeploymentScenario<?> deploymentScenario) {
         ProjectBuilderTestProvider provider = new ProjectBuilderTestProvider();
-        if (Objects.nonNull(environment)) {
-            provider.init(environment);
+        if (Objects.nonNull(deploymentScenario)) {
+            provider.init(deploymentScenario);
         }
         return provider;
     }
 
-    private void init(Map<String, String> environment) {}
+    private void init(DeploymentScenario<?> deploymentScenario) {}
 
     public void testCreateAndDeployProject(WorkbenchDeployment workbenchDeployment,
                                            KieServerDeployment kieServerDeployment) {

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/SmartRouterTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/SmartRouterTestProvider.java
@@ -16,7 +16,6 @@
 package org.kie.cloud.integrationtests.testproviders;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
@@ -26,6 +25,7 @@ import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.KjarDeployer;
 import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
+import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.tests.common.client.util.Kjar;
@@ -68,17 +68,17 @@ public class SmartRouterTestProvider {
      * 
      * @return provider instance
      */
-    public static SmartRouterTestProvider create(Map<String, String> environment) {
+    public static SmartRouterTestProvider create(DeploymentScenario<?> deploymentScenario) {
         SmartRouterTestProvider provider = new SmartRouterTestProvider();
-        if (Objects.nonNull(environment)) {
-            provider.init(environment);
+        if (Objects.nonNull(deploymentScenario)) {
+            provider.init(deploymentScenario);
         }
         return provider;
     }
 
-    private void init(Map<String, String> environment) {
-        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(environment);
-        KjarDeployer.create(Kjar.DEFINITION_101_SNAPSHOT).deploy(environment);
+    private void init(DeploymentScenario<?> deploymentScenario) {
+        KjarDeployer.create(Kjar.DEFINITION_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
+        KjarDeployer.create(Kjar.DEFINITION_101_SNAPSHOT).deploy(deploymentScenario.getMavenRepositoryDeployment());
     }
 
     public void testRouterLoadBalancing(WorkbenchDeployment workbenchDeployment,


### PR DESCRIPTION
Still doing some minor testing, but the PR should be moreless ready.

Should provide a bit cleaner implementation of MavenDeployer.
Should we still support using Maven repository deployed in dedicated namespace? Or rather completely drop it (as it most likely won't be used anyway)?