### PR TITLE
[7.30.x] Add test class name to log folder

### DIFF
--- a/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractMethodIsolatedCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractMethodIsolatedCloudIntegrationTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractMethodIsolatedCloudIntegrationTest<T extends Deplo
     @Before
     public void initializeDeployment() {
         deploymentScenario = createDeploymentScenario(AbstractCloudIntegrationTest.deploymentScenarioFactory);
-        deploymentScenario.setLogFolderName(testName.getMethodName());
+        deploymentScenario.setLogFolderName(this.getClass().getSimpleName() + "-" + testName.getMethodName());
 
         ScenarioDeployer.deployScenario(deploymentScenario);
     }


### PR DESCRIPTION
To distinguish logs from tests with same method name.