### PR TITLE
Un ignored some tests after RHPAM-1544 is fixed

### DIFF
--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
@@ -18,7 +18,6 @@ package org.kie.cloud.integrationtests.ldap;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
@@ -88,7 +87,6 @@ public class ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest ex
     }
 
     @Test
-    @Ignore("Ignored as the tests are affected by RHPAM-1544. Unignore when the JIRA will be fixed. https://issues.jboss.org/browse/RHPAM-1544")
     public void testCreateAndDeployProject() {
         projectBuilderTestProvider.testCreateAndDeployProject(deploymentScenario.getWorkbenchDeployment(),
                                                               deploymentScenario.getKieServerDeployment());

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
@@ -20,7 +20,6 @@ import java.util.UUID;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
@@ -96,7 +95,6 @@ public class ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest ext
     }
 
     @Test
-    @Ignore("Ignored as the tests are affected by RHPAM-1544. Unignore when the JIRA will be fixed. https://issues.jboss.org/browse/RHPAM-1544")
     public void testCreateAndDeployProject() {
         projectBuilderTestProvider.testCreateAndDeployProject(deploymentScenario.getWorkbenchDeployment(),
                                                               deploymentScenario.getKieServerDeployment());


### PR DESCRIPTION
After https://issues.redhat.com/browse/RHPAM-1544 is fixed, I've recovered a couple of tests that were ignored. I tried first in local and they worked. 