### PR TITLE
[RHPAM-2175] Remove all the users and create only one: app user and app password. …

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/constants/DeploymentConstants.java
@@ -24,18 +24,11 @@ public class DeploymentConstants implements Constants {
         TestInfoPrinter.printTestConstants();
     }
 
-    public static final String KIE_SERVER_USER = "org.kie.server.user";
-    public static final String KIE_SERVER_PASSWORD = "org.kie.server.pwd";
     public static final String HIBERNATE_PERSISTENCE_DIALECT = "hibernate.dialect";
 
-    public static final String WORKBENCH_USER = "org.kie.workbench.user";
-    public static final String WORKBENCH_PASSWORD = "org.kie.workbench.pwd";
-
-    public static final String WORKBENCH_MAVEN_USER = "org.kie.workbench.maven.user";
-    public static final String WORKBENCH_MAVEN_PASSWORD = "org.kie.workbench.maven.pwd";
-
-    public static final String CONTROLLER_USER = "org.kie.server.controller.user";
-    public static final String CONTROLLER_PASSWORD = "org.kie.server.controller.pwd";
+    public static final String APP_USER = "kie.app.user";
+    public static final String APP_PASSWORD = "kie.app.password";
+    public static final String APP_CREDENTIALS_SECRET_NAME = "kie.app.credentials-secret-name";
 
     public static final String AMQ_USERNAME = "amq.username";
     public static final String AMQ_PASSWORD = "amq.password";
@@ -66,36 +59,16 @@ public class DeploymentConstants implements Constants {
 
     public static final String CERTIFICATE_DIR = "certificate.dir";
 
-    public static String getKieServerUser() {
-        return System.getProperty(KIE_SERVER_USER);
+    public static String getAppUser() {
+        return System.getProperty(APP_USER);
     }
 
-    public static String getKieServerPassword() {
-        return System.getProperty(KIE_SERVER_PASSWORD);
+    public static String getAppPassword() {
+        return System.getProperty(APP_PASSWORD);
     }
 
-    public static String getWorkbenchUser() {
-        return System.getProperty(WORKBENCH_USER);
-    }
-
-    public static String getWorkbenchPassword() {
-        return System.getProperty(WORKBENCH_PASSWORD);
-    }
-
-    public static String getWorkbenchMavenUser() {
-        return System.getProperty(WORKBENCH_MAVEN_USER);
-    }
-
-    public static String getWorkbenchMavenPassword() {
-        return System.getProperty(WORKBENCH_MAVEN_PASSWORD);
-    }
-
-    public static String getControllerUser() {
-        return System.getProperty(CONTROLLER_USER);
-    }
-
-    public static String getControllerPassword() {
-        return System.getProperty(CONTROLLER_PASSWORD);
+    public static String getAppCredentialsSecretName() {
+        return System.getProperty(APP_CREDENTIALS_SECRET_NAME);
     }
 
     public static String getAmqUsername() {

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder.java
@@ -67,15 +67,6 @@ public interface ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesSc
     ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder withLdapSettings(LdapSettings ldapSettings);
 
     /**
-     * Return setup builder with Business Central user for the maven repository.
-     *
-     * @param user Business Central Maven repo user name.
-     * @param password Business Central Maven repo user password.
-     * @return Builder with configured Business Central Maven repo user.
-     */
-    ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder withBusinessCentralMavenUser(String user, String password);
-
-    /**
      * Return setup builder with configure Workbench http hostname.
      *
      * @param hostname HTTP hostname for Workbench

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchKieServerPersistentScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchKieServerPersistentScenarioBuilder.java
@@ -36,15 +36,6 @@ public interface WorkbenchKieServerPersistentScenarioBuilder extends DeploymentS
     WorkbenchKieServerPersistentScenarioBuilder deploySso();
 
     /**
-     * Return setup builder with Business Central user for the maven repository.
-     *
-     * @param user Business Central Maven repo user name.
-     * @param password Business Central Maven repo user password.
-     * @return Builder with configured Business Central Maven repo user.
-     */
-    WorkbenchKieServerPersistentScenarioBuilder withBusinessCentralMavenUser(String user, String password);
-
-    /**
      * @param kieServerId kie-server id
      * @return Builder with kie-server id set
      */

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioApb.java
@@ -18,7 +18,6 @@ package org.kie.cloud.openshift.scenario;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -198,8 +197,8 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
 
     private WorkbenchDeployment createWorkbenchRuntimeDeployment(Project project) {
         WorkbenchRuntimeDeploymentImpl workbenchRuntimeDeployment = new WorkbenchRuntimeDeploymentImpl(project);
-        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         return workbenchRuntimeDeployment;
     }
@@ -212,8 +211,8 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
 
     private KieServerDeploymentImpl createKieServerDeployment(Project project, String kieServerIndex) {
         KieServerDeploymentImpl kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
         kieServerDeployment.setServiceSuffix("-" + kieServerIndex);
 
         return kieServerDeployment;

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioApb.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -84,8 +83,8 @@ public class KieServerWithExternalDatabaseScenarioApb extends OpenShiftScenario<
         project.processApbRun(ApbImageGetter.fromImageStream(), extraVars);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         logger.info("Waiting for Kie server deployment to become ready.");
         kieServerDeployment.waitForScale();

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerPersistentScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerPersistentScenarioApb.java
@@ -19,7 +19,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -86,13 +85,13 @@ public class WorkbenchKieServerPersistentScenarioApb extends OpenShiftScenario<W
         project.processApbRun(ApbImageGetter.fromImageStream(), extraVars);
 
         workbenchDeployment = new WorkbenchDeploymentImpl(project);
-        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
         kieServerDeployment.setServiceSuffix("-0");
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         logger.info("Waiting for Workbench deployment to become ready.");
         workbenchDeployment.waitForScale();

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioApb.java
@@ -19,7 +19,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,7 +77,7 @@ public class WorkbenchKieServerScenarioApb extends OpenShiftScenario<WorkbenchKi
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
         kieServerDeployment.setServiceSuffix("-0");
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
         kieServerDeployment.setPassword(ApbConstants.DefaultUser.PASSWORD);
 
         if (deployPrometheus) {

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioApb.java
@@ -18,7 +18,6 @@ package org.kie.cloud.openshift.scenario;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -101,8 +100,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScena
 
         kieServerDeployment = createKieServerDeployment(project);
         kieServerDeployment.setServiceSuffix("-0");
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
         databaseDeployment = new DatabaseDeploymentImpl(project);
         databaseDeployment.setServiceSuffix("-0");
         amqDeployment = createAmqDeployment(project);
@@ -205,8 +204,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScena
 
     private KieServerDeploymentImpl createKieServerDeployment(Project project) {
         KieServerDeploymentImpl deployment = new KieServerDeploymentImpl(project);
-        deployment.setUsername(DeploymentConstants.getKieServerUser());
-        deployment.setPassword(DeploymentConstants.getKieServerPassword());
+        deployment.setUsername(DeploymentConstants.getAppUser());
+        deployment.setPassword(DeploymentConstants.getAppPassword());
 
         return deployment;
     }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderApb.java
@@ -49,14 +49,14 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
         extraVars.put(OpenShiftApbConstants.APB_BUSINESSCENTRAL_REPLICAS, "1"); //RHPAM-1662
         extraVars.put(OpenShiftApbConstants.SMARTROUTER_VOLUME_SIZE, "64Mi");
         extraVars.put(OpenShiftApbConstants.BUSINESSCENTRAL_VOLUME_SIZE, "64Mi");
-        
+
         // Users
-        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        extraVars.put(OpenShiftApbConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
-        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_USER, DeploymentConstants.getControllerUser());
-        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_SERVER_PWD, DeploymentConstants.getAppPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_PWD, DeploymentConstants.getAppPassword());
     }
 
     @Override
@@ -92,13 +92,6 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
     @Override
     public ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder withLdapSettings(LdapSettings ldapSettings) {
         extraVars.putAll(ldapSettings.getEnvVariables());
-        return this;
-    }
-
-    @Override
-    public ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder withBusinessCentralMavenUser(String user, String password) {
-        extraVars.put(OpenShiftApbConstants.BUSINESS_CENTRAL_MAVEN_USERNAME, user);
-        extraVars.put(OpenShiftApbConstants.BUSINESS_CENTRAL_MAVEN_PASSWORD, password);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderApb.java
@@ -43,12 +43,12 @@ public class KieServerWithExternalDatabaseScenarioBuilderApb extends AbstractOpe
         //apb_kieserver_image_stream_name -- can be also required, has default value (now rhpam72-kieserver-openshift)
 
         // Users
-        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        extraVars.put(OpenShiftApbConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
-        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_USER, DeploymentConstants.getControllerUser());
-        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_SERVER_PWD, DeploymentConstants.getAppPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_PWD, DeploymentConstants.getAppPassword());
 
         //extraVars.put(OpenShiftApbConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
     }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderApb.java
@@ -44,14 +44,12 @@ public class WorkbenchKieServerPersistentScenarioBuilderApb extends AbstractOpen
         extraVars.put(OpenShiftApbConstants.APB_IMAGE_STREAM_TAG, OpenShiftConstants.getApbKieImageStreamTag());
         extraVars.put(OpenShiftApbConstants.BUSINESSCENTRAL_VOLUME_SIZE, "1Gi");
 
-        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        extraVars.put(OpenShiftApbConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
-        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_USER, DeploymentConstants.getControllerUser());
-        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
-        extraVars.put(propertyNames.workbenchMavenUserName(), DeploymentConstants.getWorkbenchMavenUser());
-        extraVars.put(propertyNames.workbenchMavenPassword(), DeploymentConstants.getWorkbenchMavenPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_SERVER_PWD, DeploymentConstants.getAppPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_PWD, DeploymentConstants.getAppPassword());
     }
 
     @Override
@@ -70,13 +68,6 @@ public class WorkbenchKieServerPersistentScenarioBuilderApb extends AbstractOpen
         deploySSO = true;
         extraVars.put(OpenShiftApbConstants.SSO_USER, DeploymentConstants.getSsoServiceUser());
         extraVars.put(OpenShiftApbConstants.SSO_PWD, DeploymentConstants.getSsoServicePassword());
-        return this;
-    }
-
-    @Override
-    public WorkbenchKieServerPersistentScenarioBuilder withBusinessCentralMavenUser(String user, String password) {
-        extraVars.put(propertyNames.workbenchMavenUserName(), user);
-        extraVars.put(propertyNames.workbenchMavenPassword(), password);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerScenarioBuilderApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerScenarioBuilderApb.java
@@ -38,7 +38,7 @@ public class WorkbenchKieServerScenarioBuilderApb extends AbstractOpenshiftScena
         extraVars.put(OpenShiftApbConstants.APB_KIESERVER_DB_TYPE, ApbConstants.DbType.H2);
         extraVars.put(OpenShiftApbConstants.APB_IMAGE_STREAM_TAG, OpenShiftConstants.getApbKieImageStreamTag());
 
-        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
+        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getAppUser());
     }
 
     @Override

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilderApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilderApb.java
@@ -51,12 +51,12 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenari
         extraVars.put(OpenShiftApbConstants.BUSINESSCENTRAL_VOLUME_SIZE, "64Mi");
 
         // Users
-        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        extraVars.put(OpenShiftApbConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
-        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_USER, DeploymentConstants.getControllerUser());
-        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_SERVER_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_SERVER_PWD, DeploymentConstants.getAppPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword());
+        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_USER, DeploymentConstants.getAppUser());
+        extraVars.put(OpenShiftApbConstants.KIE_CONTROLLER_PWD, DeploymentConstants.getAppPassword());
 
         // AMQ
         extraVars.put(OpenShiftApbConstants.AMQ_INTEGRATION_ENABLE, "true");

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl.java
@@ -109,12 +109,12 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl extends O
         new SupplierWaiter<KieApp>(() -> getKieAppClient().withName(OpenShiftConstants.getKieApplicationName()).get(), kieApp -> kieApp.getStatus() != null).reason("Waiting for reconciliation to initialize all fields.").timeout(TimeUnit.MINUTES,1).waitFor();
 
         workbenchDeployment = new WorkbenchOperatorDeployment(project, getKieAppClient());
-        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         databaseDeployment = new DatabaseDeploymentImpl(project);
 

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ClusteredWorkbenchKieServerPersistentScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ClusteredWorkbenchKieServerPersistentScenarioImpl.java
@@ -101,12 +101,12 @@ public class ClusteredWorkbenchKieServerPersistentScenarioImpl extends OpenShift
         new SupplierWaiter<KieApp>(() -> getKieAppClient().withName(OpenShiftConstants.getKieApplicationName()).get(), kieApp -> kieApp.getStatus() != null).reason("Waiting for reconciliation to initialize all fields.").timeout(TimeUnit.MINUTES,1).waitFor();
 
         workbenchDeployment = new WorkbenchOperatorDeployment(project, getKieAppClient());
-        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         logger.info("Waiting until all services are created.");
         try {

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioImpl.java
@@ -188,8 +188,8 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
 
     private WorkbenchDeployment createWorkbenchRuntimeDeployment(Project project) {
         WorkbenchRuntimeDeploymentImpl workbenchRuntimeDeployment = new WorkbenchRuntimeOperatorDeployment(project, getKieAppClient());
-        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getAppPassword());
         return workbenchRuntimeDeployment;
     }
 
@@ -200,15 +200,15 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
 
     private KieServerDeploymentImpl createKieServerDeployment(Project project) {
         KieServerDeploymentImpl kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
         return kieServerDeployment;
     }
 
     private KieServerDeploymentImpl createKieServerDeployment(Project project, String serviceSuffix) {
         KieServerDeploymentImpl kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
         kieServerDeployment.setServiceSuffix(serviceSuffix);
         return kieServerDeployment;
     }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ImmutableKieServerAmqScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ImmutableKieServerAmqScenarioImpl.java
@@ -97,8 +97,8 @@ public class ImmutableKieServerAmqScenarioImpl extends OpenShiftOperatorScenario
         new SupplierWaiter<KieApp>(() -> getKieAppClient().withName(OpenShiftConstants.getKieApplicationName()).get(), kieApp -> kieApp.getStatus() != null).reason("Waiting for reconciliation to initialize all fields.").timeout(TimeUnit.MINUTES,1).waitFor();
 
         kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         amqDeployment = new AmqDeploymentImpl(project);
         amqDeployment.setUsername(DeploymentConstants.getAmqUsername());

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ImmutableKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ImmutableKieServerScenarioImpl.java
@@ -85,8 +85,8 @@ public class ImmutableKieServerScenarioImpl extends OpenShiftOperatorScenario<Im
         new SupplierWaiter<KieApp>(() -> getKieAppClient().withName(OpenShiftConstants.getKieApplicationName()).get(), kieApp -> kieApp.getStatus() != null).reason("Waiting for reconciliation to initialize all fields.").timeout(TimeUnit.MINUTES,1).waitFor();
 
         kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         logger.info("Waiting until all services are created.");
         try {

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchKieServerPersistentScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchKieServerPersistentScenarioImpl.java
@@ -93,12 +93,12 @@ public class WorkbenchKieServerPersistentScenarioImpl extends OpenShiftOperatorS
         new SupplierWaiter<KieApp>(() -> getKieAppClient().withName(OpenShiftConstants.getKieApplicationName()).get(), kieApp -> kieApp.getStatus() != null).reason("Waiting for reconciliation to initialize all fields.").timeout(TimeUnit.MINUTES,1).waitFor();
 
         workbenchDeployment = new WorkbenchOperatorDeployment(project, getKieAppClient());
-        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         logger.info("Waiting until all services are created.");
         try {

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchKieServerScenarioImpl.java
@@ -67,12 +67,12 @@ public class WorkbenchKieServerScenarioImpl extends OpenShiftOperatorScenario<Wo
         new SupplierWaiter<KieApp>(() -> getKieAppClient().withName(OpenShiftConstants.getKieApplicationName()).get(), kieApp -> kieApp.getStatus() != null).reason("Waiting for reconciliation to initialize all fields.").timeout(TimeUnit.MINUTES,1).waitFor();
 
         workbenchDeployment = new WorkbenchOperatorDeployment(project, getKieAppClient());
-        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         if (deployPrometheus) {
             prometheusDeployment = PrometheusDeployer.deployAsOperator(project, kieServerDeployment);

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioImpl.java
@@ -108,14 +108,14 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenari
         new SupplierWaiter<KieApp>(() -> getKieAppClient().withName(OpenShiftConstants.getKieApplicationName()).get(), kieApp -> kieApp.getStatus() != null).reason("Waiting for reconciliation to initialize all fields.").timeout(TimeUnit.MINUTES,1).waitFor();
 
         workbenchRuntimeDeployment = new WorkbenchRuntimeOperatorDeployment(project, getKieAppClient());
-        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         smartRouterDeployment = new SmartRouterOperatorDeployment(project, getKieAppClient());
 
         kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         databaseDeployment = new DatabaseDeploymentImpl(project);
 

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl.java
@@ -96,14 +96,14 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioIm
         new SupplierWaiter<KieApp>(() -> getKieAppClient().withName(OpenShiftConstants.getKieApplicationName()).get(), kieApp -> kieApp.getStatus() != null).reason("Waiting for reconciliation to initialize all fields.").timeout(TimeUnit.MINUTES,1).waitFor();
 
         workbenchRuntimeDeployment = new WorkbenchRuntimeOperatorDeployment(project, getKieAppClient());
-        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         smartRouterDeployment = new SmartRouterOperatorDeployment(project, getKieAppClient());
 
         kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         databaseDeployment = new DatabaseDeploymentImpl(project);
 

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
@@ -27,7 +27,6 @@ import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
 import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorConstants;
 import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorEnvironments;
-import org.kie.cloud.openshift.operator.constants.ProjectSpecificPropertyNames;
 import org.kie.cloud.openshift.operator.model.KieApp;
 import org.kie.cloud.openshift.operator.model.components.Auth;
 import org.kie.cloud.openshift.operator.model.components.CommonConfig;
@@ -45,17 +44,14 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
                                                                               ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder {
 
     private KieApp kieApp = new KieApp();
-    private final ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();
     private boolean deploySSO = false;
 
     public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl() {
         isScenarioAllowed();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_USER, DeploymentConstants.getKieServerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_MAVEN_USER, DeploymentConstants.getWorkbenchUser()));
-        authenticationEnvVars.add(new Env(propertyNames.workbenchMavenUserName(), DeploymentConstants.getWorkbenchUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword()));
 
         kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
         kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.AUTHORING_HA);
@@ -68,11 +64,8 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
         });
 
         CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getWorkbenchUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getWorkbenchPassword());
-        commonConfig.setServerPassword(DeploymentConstants.getKieServerPassword());
-        commonConfig.setControllerPassword(DeploymentConstants.getControllerPassword());
-        commonConfig.setMavenPassword(DeploymentConstants.getWorkbenchPassword());
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
         kieApp.getSpec().setCommonConfig(commonConfig);
 
         Server server = new Server();

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl.java
@@ -26,7 +26,6 @@ import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
 import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorConstants;
 import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorEnvironments;
-import org.kie.cloud.openshift.operator.constants.ProjectSpecificPropertyNames;
 import org.kie.cloud.openshift.operator.model.KieApp;
 import org.kie.cloud.openshift.operator.model.components.CommonConfig;
 import org.kie.cloud.openshift.operator.model.components.Console;
@@ -41,17 +40,14 @@ public class ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl extends Ab
                                                                       ClusteredWorkbenchKieServerPersistentScenarioBuilder {
 
     private KieApp kieApp = new KieApp();
-    private final ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();
     private boolean deploySSO = false;
 
     public ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl() {
         isScenarioAllowed();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_USER, DeploymentConstants.getKieServerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_MAVEN_USER, DeploymentConstants.getWorkbenchUser()));
-        authenticationEnvVars.add(new Env(propertyNames.workbenchMavenUserName(), DeploymentConstants.getWorkbenchUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword()));
 
         kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
         kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.AUTHORING_HA);
@@ -64,11 +60,8 @@ public class ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl extends Ab
         });
 
         CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getWorkbenchUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getWorkbenchPassword());
-        commonConfig.setServerPassword(DeploymentConstants.getKieServerPassword());
-        commonConfig.setControllerPassword(DeploymentConstants.getControllerPassword());
-        commonConfig.setMavenPassword(DeploymentConstants.getWorkbenchPassword());
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
         kieApp.getSpec().setCommonConfig(commonConfig);
 
         Server server = new Server();

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl.java
@@ -28,7 +28,6 @@ import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
 import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorConstants;
 import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorEnvironments;
-import org.kie.cloud.openshift.operator.constants.ProjectSpecificPropertyNames;
 import org.kie.cloud.openshift.operator.model.KieApp;
 import org.kie.cloud.openshift.operator.model.components.Auth;
 import org.kie.cloud.openshift.operator.model.components.CommonConfig;
@@ -47,24 +46,20 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
                                                                                               implements ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder {
 
     private KieApp kieApp = new KieApp();
-    private final ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();
     private boolean deploySSO = false;
 
     public ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl() {
         isScenarioAllowed();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_USER, DeploymentConstants.getKieServerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser()));
-
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword()));
         kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
         kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.PRODUCTION);
 
         CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getWorkbenchUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getWorkbenchPassword());
-        commonConfig.setServerPassword(DeploymentConstants.getKieServerPassword());
-        commonConfig.setControllerPassword(DeploymentConstants.getControllerPassword());
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
         kieApp.getSpec().setCommonConfig(commonConfig);
 
         OpenShiftOperatorConstants.getKieImageRegistryCustom().ifPresent(registry -> {
@@ -140,17 +135,6 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
             ssoClient.setName("kie-server-" + i + "-client");
             ssoClient.setSecret("kie-server-" + i + "-secret");
             servers[i].setSsoClient(ssoClient);
-        }
-        return this;
-    }
-
-    @Override
-    public ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder withBusinessCentralMavenUser(String user, String password) {
-        kieApp.getSpec().getCommonConfig().setMavenPassword(password);
-        kieApp.getSpec().getObjects().getConsole().addEnv(new Env(ImageEnvVariables.KIE_MAVEN_USER, user));
-
-        for (Server server : kieApp.getSpec().getObjects().getServers()) {
-            server.addEnv(new Env(propertyNames.workbenchMavenUserName(), user));
         }
         return this;
     }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerAmqScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerAmqScenarioBuilderImpl.java
@@ -52,9 +52,8 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftS
         isScenarioAllowed();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_USER, DeploymentConstants.getKieServerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_MAVEN_USER, DeploymentConstants.getWorkbenchUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword()));
 
         kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
         kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.PRODUCTION_IMMUTABLE);
@@ -67,11 +66,8 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftS
         });
 
         CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getWorkbenchUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getWorkbenchPassword());
-        commonConfig.setServerPassword(DeploymentConstants.getKieServerPassword());
-        commonConfig.setControllerPassword(DeploymentConstants.getControllerPassword());
-        commonConfig.setMavenPassword(DeploymentConstants.getWorkbenchPassword());
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
         kieApp.getSpec().setCommonConfig(commonConfig);
 
         // These values are defined in pom.xml where keystore and truststore are generated

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerScenarioBuilderImpl.java
@@ -51,9 +51,8 @@ public class ImmutableKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
         isScenarioAllowed();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_USER, DeploymentConstants.getKieServerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_MAVEN_USER, DeploymentConstants.getWorkbenchUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword()));
 
         kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
         kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.PRODUCTION_IMMUTABLE);
@@ -66,11 +65,8 @@ public class ImmutableKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
         });
 
         CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getWorkbenchUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getWorkbenchPassword());
-        commonConfig.setServerPassword(DeploymentConstants.getKieServerPassword());
-        commonConfig.setControllerPassword(DeploymentConstants.getControllerPassword());
-        commonConfig.setMavenPassword(DeploymentConstants.getWorkbenchPassword());
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
         kieApp.getSpec().setCommonConfig(commonConfig);
 
         Server server = new Server();

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
@@ -27,7 +27,6 @@ import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
 import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorConstants;
 import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorEnvironments;
-import org.kie.cloud.openshift.operator.constants.ProjectSpecificPropertyNames;
 import org.kie.cloud.openshift.operator.model.KieApp;
 import org.kie.cloud.openshift.operator.model.components.Auth;
 import org.kie.cloud.openshift.operator.model.components.CommonConfig;
@@ -43,15 +42,12 @@ import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
 public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<WorkbenchKieServerPersistentScenario> implements WorkbenchKieServerPersistentScenarioBuilder {
 
     private KieApp kieApp = new KieApp();
-    private final ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();
     private boolean deploySSO = false;
 
     public WorkbenchKieServerPersistentScenarioBuilderImpl() {
         List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_USER, DeploymentConstants.getKieServerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_MAVEN_USER, DeploymentConstants.getWorkbenchUser()));
-        authenticationEnvVars.add(new Env(propertyNames.workbenchMavenUserName(), DeploymentConstants.getWorkbenchUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword()));
 
         kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
         kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.AUTHORING);
@@ -64,11 +60,8 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
         });
 
         CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getWorkbenchUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getWorkbenchPassword());
-        commonConfig.setServerPassword(DeploymentConstants.getKieServerPassword());
-        commonConfig.setControllerPassword(DeploymentConstants.getControllerPassword());
-        commonConfig.setMavenPassword(DeploymentConstants.getWorkbenchPassword());
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
         kieApp.getSpec().setCommonConfig(commonConfig);
 
         Server server = new Server();
@@ -105,17 +98,6 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
             ssoClient.setName("kie-server-" + i + "-client");
             ssoClient.setSecret("kie-server-" + i + "-secret");
             servers[i].setSsoClient(ssoClient);
-        }
-        return this;
-    }
-
-    @Override
-    public WorkbenchKieServerPersistentScenarioBuilder withBusinessCentralMavenUser(String user, String password) {
-        kieApp.getSpec().getCommonConfig().setMavenPassword(password);
-        kieApp.getSpec().getObjects().getConsole().addEnv(new Env(ImageEnvVariables.KIE_MAVEN_USER, user));
-
-        for (Server server : kieApp.getSpec().getObjects().getServers()) {
-            server.addEnv(new Env(propertyNames.workbenchMavenUserName(), user));
         }
         return this;
     }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
@@ -42,7 +42,7 @@ public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
 
     public WorkbenchKieServerScenarioBuilderImpl() {
         List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_USER, DeploymentConstants.getKieServerUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
 
         kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
         kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.TRIAL);
@@ -55,9 +55,8 @@ public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
         });
 
         CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getWorkbenchUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getWorkbenchPassword());
-        commonConfig.setServerPassword(DeploymentConstants.getKieServerPassword());
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
         kieApp.getSpec().setCommonConfig(commonConfig);
 
         Server server = new Server();

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilderImpl.java
@@ -55,8 +55,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenari
         isScenarioAllowed();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_USER, DeploymentConstants.getKieServerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword()));
 
         kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
         kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.PRODUCTION_IMMUTABLE);
@@ -69,11 +69,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenari
         });
 
         CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getWorkbenchUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getWorkbenchPassword());
-        commonConfig.setServerPassword(DeploymentConstants.getKieServerPassword());
-        commonConfig.setControllerPassword(DeploymentConstants.getControllerPassword());
-        commonConfig.setMavenPassword(DeploymentConstants.getWorkbenchPassword());
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
         kieApp.getSpec().setCommonConfig(commonConfig);
 
         // These values are defined in pom.xml where keystore and truststore are generated

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl.java
@@ -55,8 +55,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBu
         isScenarioAllowed();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_USER, DeploymentConstants.getKieServerUser()));
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword()));
 
         kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
         kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.PRODUCTION_IMMUTABLE);
@@ -69,11 +69,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBu
         });
 
         CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getWorkbenchUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getWorkbenchPassword());
-        commonConfig.setServerPassword(DeploymentConstants.getKieServerPassword());
-        commonConfig.setControllerPassword(DeploymentConstants.getControllerPassword());
-        commonConfig.setMavenPassword(DeploymentConstants.getWorkbenchPassword());
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
         kieApp.getSpec().setCommonConfig(commonConfig);
 
         Server server = new Server();

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/DroolsSpecificPropertyNames.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/DroolsSpecificPropertyNames.java
@@ -18,16 +18,6 @@ package org.kie.cloud.openshift.constants;
 public class DroolsSpecificPropertyNames implements ProjectSpecificPropertyNames {
 
     @Override
-    public String workbenchMavenUserName() {
-        return OpenShiftTemplateConstants.DECISION_CENTRAL_MAVEN_USERNAME;
-    }
-
-    @Override
-    public String workbenchMavenPassword() {
-        return OpenShiftTemplateConstants.DECISION_CENTRAL_MAVEN_PASSWORD;
-    }
-
-    @Override
     public String workbenchHttpsSecret() {
         return OpenShiftTemplateConstants.DECISION_CENTRAL_HTTPS_SECRET;
     }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/JbpmSpecificPropertyNames.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/JbpmSpecificPropertyNames.java
@@ -18,16 +18,6 @@ package org.kie.cloud.openshift.constants;
 public class JbpmSpecificPropertyNames implements ProjectSpecificPropertyNames {
 
     @Override
-    public String workbenchMavenUserName() {
-        return OpenShiftTemplateConstants.BUSINESS_CENTRAL_MAVEN_USERNAME;
-    }
-
-    @Override
-    public String workbenchMavenPassword() {
-        return OpenShiftTemplateConstants.BUSINESS_CENTRAL_MAVEN_PASSWORD;
-    }
-
-    @Override
     public String workbenchHttpsSecret() {
         return OpenShiftTemplateConstants.BUSINESS_CENTRAL_HTTPS_SECRET;
     }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/OpenShiftTemplateConstants.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/OpenShiftTemplateConstants.java
@@ -21,13 +21,11 @@ public class OpenShiftTemplateConstants {
     // Used as a generic password for all passwords in the template (Workbench user, Kie server user, Controller user, Workbench maven user)
     public static final String DEFAULT_PASSWORD = "DEFAULT_PASSWORD";
 
-    public static final String KIE_ADMIN_USER = "KIE_ADMIN_USER";
-    public static final String KIE_ADMIN_PWD = "KIE_ADMIN_PWD";
+    public static final String CREDENTIALS_SECRET = "CREDENTIALS_SECRET";
 
     public static final String GIT_HOOKS_DIR = "GIT_HOOKS_DIR";
 
-    public static final String KIE_SERVER_USER = "KIE_SERVER_USER";
-    public static final String KIE_SERVER_PWD = "KIE_SERVER_PWD";
+    public static final String KIE_ADMIN_USER = "KIE_ADMIN_USER";
     public static final String KIE_SERVER_HOST = "KIE_SERVER_HOST";
     public static final String KIE_SERVER_PORT = "KIE_SERVER_PORT";
     public static final String KIE_SERVER_ID = "KIE_SERVER_ID";
@@ -40,8 +38,6 @@ public class OpenShiftTemplateConstants {
     public static final String KIE_SERVER_CONTROLLER_PROTOCOL = "KIE_SERVER_CONTROLLER_PROTOCOL";
     public static final String KIE_SERVER_CONTROLLER_HOST = "KIE_SERVER_CONTROLLER_HOST";
     public static final String KIE_SERVER_CONTROLLER_PORT = "KIE_SERVER_CONTROLLER_PORT";
-    public static final String KIE_SERVER_CONTROLLER_USER = "KIE_SERVER_CONTROLLER_USER";
-    public static final String KIE_SERVER_CONTROLLER_PWD = "KIE_SERVER_CONTROLLER_PWD";
     public static final String KIE_SERVER_CONTROLLER_SERVICE = "KIE_SERVER_CONTROLLER_SERVICE";
 
     public static final String KIE_SERVER_ROUTER_ID = "KIE_SERVER_ROUTER_ID";
@@ -58,14 +54,10 @@ public class OpenShiftTemplateConstants {
 
     public static final String BUSINESS_CENTRAL_MEMORY_LIMIT = "BUSINESS_CENTRAL_MEMORY_LIMIT";
     public static final String DECISION_CENTRAL_MEMORY_LIMIT = "DECISION_CENTRAL_MEMORY_LIMIT";
-    
+
     // Intentionally not public. Use ProjectSpecificPropertyNames to get proper variant based on product profile
     static final String BUSINESS_CENTRAL_MAVEN_SERVICE = "BUSINESS_CENTRAL_MAVEN_SERVICE";
-    static final String BUSINESS_CENTRAL_MAVEN_USERNAME = "BUSINESS_CENTRAL_MAVEN_USERNAME";
-    static final String BUSINESS_CENTRAL_MAVEN_PASSWORD = "BUSINESS_CENTRAL_MAVEN_PASSWORD";
     static final String DECISION_CENTRAL_MAVEN_SERVICE = "DECISION_CENTRAL_MAVEN_SERVICE";
-    static final String DECISION_CENTRAL_MAVEN_USERNAME = "DECISION_CENTRAL_MAVEN_USERNAME";
-    static final String DECISION_CENTRAL_MAVEN_PASSWORD = "DECISION_CENTRAL_MAVEN_PASSWORD";
 
     public static final String MAVEN_REPO_URL = "MAVEN_REPO_URL";
     public static final String MAVEN_REPO_USERNAME = "MAVEN_REPO_USERNAME";

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/ProjectSpecificPropertyNames.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/constants/ProjectSpecificPropertyNames.java
@@ -28,10 +28,6 @@ import org.kie.cloud.openshift.template.ProjectProfile;
  */
 public interface ProjectSpecificPropertyNames {
 
-    String workbenchMavenUserName();
-
-    String workbenchMavenPassword();
-
     String workbenchHttpsSecret();
 
     String workbenchMavenService();

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl.java
@@ -101,13 +101,13 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl extends K
         project.processTemplateAndCreateResources(OpenShiftTemplate.CLUSTERED_WORKBENCH_KIE_SERVER_DATABASE_PERSISTENT.getTemplateUrl(), envVariables);
 
         workbenchDeployment = new WorkbenchDeploymentImpl(project);
-        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchDeployment.setPassword(DeploymentConstants.getAppPassword());
         workbenchDeployment.scale(1);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         databaseDeployment = new DatabaseDeploymentImpl(project);
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchKieServerPersistentScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchKieServerPersistentScenarioImpl.java
@@ -92,13 +92,13 @@ public class ClusteredWorkbenchKieServerPersistentScenarioImpl extends KieCommon
         project.processTemplateAndCreateResources(OpenShiftTemplate.CLUSTERED_WORKBENCH_KIE_SERVER_PERSISTENT.getTemplateUrl(), envVariables);
 
         workbenchDeployment = new WorkbenchDeploymentImpl(project);
-        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchDeployment.setPassword(DeploymentConstants.getAppPassword());
         workbenchDeployment.scale(1);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
         kieServerDeployment.scale(1);
 
         logger.info("Waiting for Workbench deployment to become ready.");

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioImpl.java
@@ -102,16 +102,16 @@ public class ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioImpl ext
 
     private WorkbenchDeployment createWorkbenchRuntimeDeployment(Project project) {
         WorkbenchRuntimeDeploymentImpl workbenchRuntimeDeployment = new WorkbenchRuntimeDeploymentImpl(project);
-        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         return workbenchRuntimeDeployment;
     }
 
     private KieServerDeploymentImpl createKieServerDeployment(Project project) {
         KieServerDeploymentImpl kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         return kieServerDeployment;
     }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioImpl.java
@@ -180,8 +180,8 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
 
     private WorkbenchDeployment createWorkbenchRuntimeDeployment(Project project) {
         WorkbenchRuntimeDeploymentImpl workbenchRuntimeDeployment = new WorkbenchRuntimeDeploymentImpl(project);
-        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchRuntimeDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchRuntimeDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         return workbenchRuntimeDeployment;
     }
@@ -195,8 +195,8 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
 
     private KieServerDeploymentImpl createKieServerDeployment(Project project, String kieServerSuffix) {
         KieServerDeploymentImpl kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
         kieServerDeployment.setServiceSuffix("-" + kieServerSuffix);
 
         return kieServerDeployment;

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ImmutableKieServerAmqScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ImmutableKieServerAmqScenarioImpl.java
@@ -84,8 +84,8 @@ public class ImmutableKieServerAmqScenarioImpl extends KieCommonScenario<Immutab
         project.processTemplateAndCreateResources(OpenShiftTemplate.KIE_SERVER_S2I_AMQ.getTemplateUrl(), envVariables);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         amqDeployment = new AmqDeploymentImpl(project);
         amqDeployment.setUsername(DeploymentConstants.getAmqUsername());

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ImmutableKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ImmutableKieServerScenarioImpl.java
@@ -72,8 +72,8 @@ public class ImmutableKieServerScenarioImpl extends KieCommonScenario<ImmutableK
         project.processTemplateAndCreateResources(OpenShiftTemplate.KIE_SERVER_HTTPS_S2I.getTemplateUrl(), envVariables);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         logger.info("Waiting for Kie server deployment to become ready.");
         kieServerDeployment.scale(1);

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerScenarioImpl.java
@@ -72,8 +72,8 @@ public class KieServerScenarioImpl extends KieCommonScenario<KieServerScenario> 
         project.processTemplateAndCreateResources(OpenShiftTemplate.KIE_SERVER.getTemplateUrl(), envVariables);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         logger.info("Waiting for Kie server deployment to become ready.");
         kieServerDeployment.waitForScale();

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioImpl.java
@@ -77,8 +77,8 @@ public class KieServerWithExternalDatabaseScenarioImpl extends KieCommonScenario
         project.processTemplateAndCreateResources(OpenShiftTemplate.KIE_SERVER_DATABASE_EXTERNAL.getTemplateUrl(), envVariables);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         logger.info("Waiting for Kie server deployment to become ready.");
         kieServerDeployment.waitForScale();

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithMySqlScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithMySqlScenarioImpl.java
@@ -81,8 +81,8 @@ public class KieServerWithMySqlScenarioImpl extends KieCommonScenario<KieServerW
         project.processTemplateAndCreateResources(OpenShiftTemplate.KIE_SERVER_MYSQL.getTemplateUrl(), envVariables);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         databaseDeployment = new DatabaseDeploymentImpl(project);
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithPostgreSqlScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithPostgreSqlScenarioImpl.java
@@ -81,8 +81,8 @@ public class KieServerWithPostgreSqlScenarioImpl extends KieCommonScenario<KieSe
         project.processTemplateAndCreateResources(OpenShiftTemplate.KIE_SERVER_POSTGRESQL.getTemplateUrl(), envVariables);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         databaseDeployment = new DatabaseDeploymentImpl(project);
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerPersistentScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerPersistentScenarioImpl.java
@@ -79,12 +79,12 @@ public class WorkbenchKieServerPersistentScenarioImpl extends KieCommonScenario<
         project.processTemplateAndCreateResources(OpenShiftTemplate.WORKBENCH_KIE_SERVER_PERSISTENT.getTemplateUrl(), envVariables);
 
         workbenchDeployment = new WorkbenchDeploymentImpl(project);
-        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        workbenchDeployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
+        workbenchDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
-        kieServerDeployment.setPassword(DeploymentConstants.getKieServerPassword());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
+        kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
         logger.info("Waiting for Workbench deployment to become ready.");
         workbenchDeployment.waitForScale();

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioImpl.java
@@ -61,11 +61,11 @@ public class WorkbenchKieServerScenarioImpl extends KieCommonScenario<WorkbenchK
         project.processTemplateAndCreateResources(OpenShiftTemplate.WORKBENCH_KIE_SERVER.getTemplateUrl(), envVariables);
 
         workbenchDeployment = new WorkbenchDeploymentImpl(project);
-        workbenchDeployment.setUsername(DeploymentConstants.getWorkbenchUser());
+        workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
         workbenchDeployment.setPassword(envVariables.get(OpenShiftTemplateConstants.DEFAULT_PASSWORD));
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
-        kieServerDeployment.setUsername(DeploymentConstants.getKieServerUser());
+        kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
         kieServerDeployment.setPassword(envVariables.get(OpenShiftTemplateConstants.DEFAULT_PASSWORD));
 
         if (deployPrometheus) {

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioImpl.java
@@ -176,8 +176,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScena
 
     private WorkbenchDeployment createWorkbenchRuntimeDeployment(Project project) {
         WorkbenchRuntimeDeploymentImpl deployment = new WorkbenchRuntimeDeploymentImpl(project);
-        deployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        deployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        deployment.setUsername(DeploymentConstants.getAppUser());
+        deployment.setPassword(DeploymentConstants.getAppPassword());
 
         return deployment;
     }
@@ -191,8 +191,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScena
 
     private KieServerDeploymentImpl createKieServerDeployment(Project project) {
         KieServerDeploymentImpl deployment = new KieServerDeploymentImpl(project);
-        deployment.setUsername(DeploymentConstants.getKieServerUser());
-        deployment.setPassword(DeploymentConstants.getKieServerPassword());
+        deployment.setUsername(DeploymentConstants.getAppUser());
+        deployment.setPassword(DeploymentConstants.getAppPassword());
 
         return deployment;
     }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenarioImpl.java
@@ -155,8 +155,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenario
 
     private WorkbenchDeployment createWorkbenchRuntimeDeployment(Project project) {
         WorkbenchRuntimeDeploymentImpl deployment = new WorkbenchRuntimeDeploymentImpl(project);
-        deployment.setUsername(DeploymentConstants.getWorkbenchUser());
-        deployment.setPassword(DeploymentConstants.getWorkbenchPassword());
+        deployment.setUsername(DeploymentConstants.getAppUser());
+        deployment.setPassword(DeploymentConstants.getAppPassword());
 
         return deployment;
     }
@@ -170,8 +170,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenario
 
     private KieServerDeploymentImpl createKieServerDeployment(Project project) {
         KieServerDeploymentImpl deployment = new KieServerDeploymentImpl(project);
-        deployment.setUsername(DeploymentConstants.getKieServerUser());
-        deployment.setPassword(DeploymentConstants.getKieServerPassword());
+        deployment.setUsername(DeploymentConstants.getAppUser());
+        deployment.setPassword(DeploymentConstants.getAppPassword());
 
         return deployment;
     }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
@@ -36,14 +36,7 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
     private final ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();
 
     public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
-        envVariables.put(propertyNames.workbenchMavenUserName(), DeploymentConstants.getWorkbenchMavenUser());
-        envVariables.put(propertyNames.workbenchMavenPassword(), DeploymentConstants.getWorkbenchMavenPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl.java
@@ -35,12 +35,7 @@ public class ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl extends Ab
     private final ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();
 
     public ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioBuilderImpl.java
@@ -33,12 +33,7 @@ public class ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioBuilderI
     private final Map<String, String> envVariables = new HashMap<>();
 
     public ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl.java
@@ -37,12 +37,7 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
     private boolean deploySso = false;
 
     public ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
@@ -81,13 +76,6 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
         deploySso = true;
         envVariables.put(OpenShiftTemplateConstants.SSO_USERNAME, DeploymentConstants.getSsoServiceUser());
         envVariables.put(OpenShiftTemplateConstants.SSO_PASSWORD, DeploymentConstants.getSsoServicePassword());
-        return this;
-    }
-
-    @Override
-    public ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder withBusinessCentralMavenUser(String user, String password) {
-        envVariables.put(propertyNames.workbenchMavenUserName(), user);
-        envVariables.put(propertyNames.workbenchMavenPassword(), password);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ImmutableKieServerAmqScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ImmutableKieServerAmqScenarioBuilderImpl.java
@@ -33,10 +33,7 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends KieScenarioBuilder
     private boolean deploySso = false;
 
     public ImmutableKieServerAmqScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         // TODO: Workaround until Maven repo with released artifacts is implemented

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ImmutableKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ImmutableKieServerScenarioBuilderImpl.java
@@ -33,10 +33,7 @@ public class ImmutableKieServerScenarioBuilderImpl extends KieScenarioBuilderImp
     private boolean deploySso = false;
 
     public ImmutableKieServerScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         // TODO: Workaround until Maven repo with released artifacts is implemented

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerScenarioBuilderImpl.java
@@ -33,10 +33,7 @@ public class KieServerScenarioBuilderImpl extends KieScenarioBuilderImpl<KieServ
     private boolean deploySso = false;
 
     public KieServerScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         // TODO: Workaround until Maven repo with released artifacts is implemented

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderImpl.java
@@ -31,8 +31,7 @@ public class KieServerWithExternalDatabaseScenarioBuilderImpl extends AbstractOp
     private final Map<String, String> envVariables = new HashMap<>();
 
     public KieServerWithExternalDatabaseScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         // TODO: Workaround until Maven repo with released artifacts is implemented

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithMySqlScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithMySqlScenarioBuilderImpl.java
@@ -33,10 +33,7 @@ public class KieServerWithMySqlScenarioBuilderImpl extends KieScenarioBuilderImp
     private boolean deploySso = false;
 
     public KieServerWithMySqlScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         // TODO: Workaround until Maven repo with released artifacts is implemented

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithPostgreSqlScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithPostgreSqlScenarioBuilderImpl.java
@@ -33,10 +33,7 @@ public class KieServerWithPostgreSqlScenarioBuilderImpl extends KieScenarioBuild
     private boolean deploySso = false;
 
     public KieServerWithPostgreSqlScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 
         // TODO: Workaround until Maven repo with released artifacts is implemented

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
@@ -35,17 +35,8 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
     private boolean deploySSO = false;
 
     public WorkbenchKieServerPersistentScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_USER, DeploymentConstants.getControllerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTROLLER_PWD, DeploymentConstants.getControllerPassword());
-        envVariables.put(OpenShiftTemplateConstants.MAVEN_REPO_USERNAME, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.MAVEN_REPO_PASSWORD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
-        envVariables.put(propertyNames.workbenchMavenUserName(), DeploymentConstants.getWorkbenchMavenUser());
-        envVariables.put(propertyNames.workbenchMavenPassword(), DeploymentConstants.getWorkbenchMavenPassword());
         envVariables.put(propertyNames.workbenchHttpsSecret(), OpenShiftConstants.getKieApplicationSecretName());
     }
 
@@ -65,13 +56,6 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
         deploySSO = true;
         envVariables.put(OpenShiftTemplateConstants.SSO_USERNAME, DeploymentConstants.getSsoServiceUser());
         envVariables.put(OpenShiftTemplateConstants.SSO_PASSWORD, DeploymentConstants.getSsoServicePassword());
-        return this;
-    }
-
-    @Override
-    public WorkbenchKieServerPersistentScenarioBuilder withBusinessCentralMavenUser(String user, String password) {
-        envVariables.put(propertyNames.workbenchMavenUserName(), user);
-        envVariables.put(propertyNames.workbenchMavenPassword(), password);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
@@ -34,10 +34,9 @@ public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
     private boolean deployPrometheus = false;
 
     public WorkbenchKieServerScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-
-        envVariables.put(OpenShiftTemplateConstants.DEFAULT_PASSWORD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
+        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getAppUser());
+        envVariables.put(OpenShiftTemplateConstants.DEFAULT_PASSWORD, DeploymentConstants.getAppPassword());
     }
 
     @Override

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioBuilderImpl.java
@@ -35,10 +35,7 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScena
     private boolean deploySso = false;
 
     public WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
         envVariables.put(propertyNames.workbenchHttpsSecret(), OpenShiftConstants.getKieApplicationSecretName());

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenarioBuilderImpl.java
@@ -36,10 +36,7 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenario
     private boolean deploySso = false;
 
     public WorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenarioBuilderImpl() {
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_USER, DeploymentConstants.getKieServerUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_PWD, DeploymentConstants.getKieServerPassword());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_USER, DeploymentConstants.getWorkbenchUser());
-        envVariables.put(OpenShiftTemplateConstants.KIE_ADMIN_PWD, DeploymentConstants.getWorkbenchPassword());
+        envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_ROUTER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
         envVariables.put(propertyNames.workbenchHttpsSecret(), OpenShiftConstants.getKieApplicationSecretName());

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/ImageEnvVariables.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/ImageEnvVariables.java
@@ -17,13 +17,8 @@ package org.kie.cloud.openshift.constants;
 
 public class ImageEnvVariables {
 
-    public static final String KIE_SERVER_USER = "KIE_SERVER_USER";
-    public static final String KIE_SERVER_PWD = "KIE_SERVER_PWD";
     public static final String KIE_ADMIN_USER = "KIE_ADMIN_USER";
     public static final String KIE_ADMIN_PWD = "KIE_ADMIN_PWD";
-    public static final String KIE_MAVEN_USER = "KIE_MAVEN_USER";
-    public static final String KIE_MAVEN_PWD = "KIE_MAVEN_PWD";
-    public static final String KIE_SERVER_CONTROLLER_USER = "KIE_SERVER_CONTROLLER_USER";
     public static final String MAVEN_REPO_USERNAME = "MAVEN_REPO_USERNAME";
 
     public static final String KIE_SERVER_ID = "KIE_SERVER_ID";

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
@@ -49,7 +49,11 @@ public class OpenShiftConstants implements Constants {
      */
     public static final String KIE_APP_NAME = "kie.app.name";
 
+    public static final String KIE_ADMIN_USER = "KIE_ADMIN_USER";
+    public static final String KIE_ADMIN_PWD = "KIE_ADMIN_PWD";
+
     public static final String SECRET_NAME = "SECRET_NAME";
+    public static final String CREDENTIALS_SECRET = "CREDENTIALS_SECRET";
     /**
      * URL pointing to OpenShift resource file containing keystore for HTTPS communication.
      */

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
@@ -57,6 +57,15 @@ public interface Project extends AutoCloseable {
     public void processTemplateAndCreateResources(URL templateUrl, Map<String, String> envVariables);
 
     /**
+     * Create a secret in the project. The value secrets will be automatically decoded into a base64 string.
+     * Example credentials yam can be found here:
+     * https://github.com/ruromero/rhpam-7-openshift-image/blob/master/example-credentials.yaml
+     * @param secretName metadata name of the secret
+     * @param secrets of the secret
+     */
+    void createSecret(String secretName, Map<String, String> secrets);
+
+    /**
      * Process APB and create all resources defined there.
      * @param image APB Image to be provision
      * @param extraVars Map of extra vars to override default values from the APB image

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.cloud.openshift.resource.impl;
 
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import cz.xtf.builder.builders.ImageStreamBuilder;
+import cz.xtf.builder.builders.SecretBuilder;
 import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShiftBinary;
 import cz.xtf.core.openshift.OpenShifts;
@@ -120,6 +121,16 @@ public class ProjectImpl implements Project {
         }
     }
 
+    @Override
+    public void createSecret(String secretName, Map<String, String> secrets) {
+        SecretBuilder builder = new SecretBuilder(secretName);
+        for (Entry<String, String> entry : secrets.entrySet()) {
+            builder.addRawData(entry.getKey(), entry.getValue());
+        }
+
+        openShift.createSecret(builder.build());
+    }
+
     static Semaphore semaphore = new Semaphore(1);
 
     @Override
@@ -165,9 +176,9 @@ public class ProjectImpl implements Project {
 
     private String formatExtraVars(Map<String, String> extraVars) {
         return extraVars.entrySet()
-                        .stream()
-                        .map(entry -> "\"" + entry.getKey() + "\":\"" + entry.getValue() + "\"")
-                        .collect(Collectors.joining(", ", "{", "}"));
+                .stream()
+                .map(entry -> "\"" + entry.getKey() + "\":\"" + entry.getValue() + "\"")
+                .collect(Collectors.joining(", ", "{", "}"));
     }
 
     @Override
@@ -180,11 +191,13 @@ public class ProjectImpl implements Project {
         }
     }
 
+    @Override
     public void createResourcesFromYaml(String yamlUrl) {
         final String output = openShiftBinaryClient().execute("create", "-f", yamlUrl);
         logger.info("Yaml resources from file {} were created by oc client. Output = {}", yamlUrl, output);
     }
 
+    @Override
     public void createResourcesFromYaml(List<String> yamlUrls) {
         final OpenShiftBinary oc = openShiftBinaryClient();
         for (String url : yamlUrls) {
@@ -193,6 +206,7 @@ public class ProjectImpl implements Project {
         }
     }
 
+    @Override
     public void createResourceFromYamlString(String yamlString) {
         try {
             final File tmpYamlFile = File.createTempFile("openshift-resource-",".yaml");
@@ -204,11 +218,13 @@ public class ProjectImpl implements Project {
         }
     }
 
+    @Override
     public void createResourcesFromYamlAsAdmin(String yamlUrl) {
         final String output = openShiftBinaryClientAsAdmin().execute("create", "-f", yamlUrl);
         logger.info("Yaml resources from file {} were created by oc client. Output = {}", yamlUrl, output);
     }
 
+    @Override
     public void createResourcesFromYamlAsAdmin(List<String> yamlUrls) {
         final OpenShiftBinary oc = openShiftBinaryClientAsAdmin();
         for (String url : yamlUrls) {
@@ -217,6 +233,7 @@ public class ProjectImpl implements Project {
         }
     }
 
+    @Override
     public void createResourcesFromYamlStringAsAdmin(String yamlString) {
         try {
             final File tmpYamlFile = File.createTempFile("openshift-resource-",".yaml");
@@ -270,6 +287,7 @@ public class ProjectImpl implements Project {
         return output;
     }
 
+    @Override
     public void close() {
         try {
             openShift.close();
@@ -286,13 +304,14 @@ public class ProjectImpl implements Project {
         return OpenShifts.getBinaryPath();
     }
 
+    @Override
     public List<Instance> getAllInstances() {
         return openShift
-                        .getPods()
-                        .stream()
-                        .filter(this::isScheduledPod)
-                        .map(pod -> OpenshiftInstanceUtil.createInstance(openShift, getName(), pod))
-                        .collect(toList());
+                .getPods()
+                .stream()
+                .filter(this::isScheduledPod)
+                .map(pod -> OpenshiftInstanceUtil.createInstance(openShift, getName(), pod))
+                .collect(toList());
     }
 
     private boolean isScheduledPod(Pod pod) {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/SsoDeployer.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/SsoDeployer.java
@@ -21,6 +21,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import cz.xtf.core.openshift.OpenShift;
+import cz.xtf.core.openshift.OpenShifts;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -32,10 +36,6 @@ import org.kie.cloud.openshift.util.sso.SsoApi;
 import org.kie.cloud.openshift.util.sso.SsoApiFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import cz.xtf.core.openshift.OpenShift;
-import cz.xtf.core.openshift.OpenShifts;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 
 public class SsoDeployer {
 
@@ -137,16 +137,8 @@ public class SsoDeployer {
         ssoApi.createRole(ADMIN);
         ssoApi.createRole(KIE_SERVER);
         ssoApi.createRole(REST_ALL);
-        ssoApi.createUser(DeploymentConstants.getWorkbenchUser(),
-                DeploymentConstants.getWorkbenchPassword(),
+        ssoApi.createUser(DeploymentConstants.getAppUser(),
+                          DeploymentConstants.getAppPassword(),
                 Arrays.asList(ADMIN, KIE_SERVER, REST_ALL));
-        ssoApi.createUser(DeploymentConstants.getControllerUser(),
-                DeploymentConstants.getControllerPassword(),
-                Arrays.asList(KIE_SERVER, REST_ALL));
-        ssoApi.createUser(DeploymentConstants.getKieServerUser(),
-                DeploymentConstants.getKieServerPassword(),
-                Arrays.asList(KIE_SERVER));
-        ssoApi.createUser(DeploymentConstants.getWorkbenchMavenUser(),
-                DeploymentConstants.getWorkbenchMavenPassword());
     }
 }

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -57,14 +57,9 @@
     <maven.repo.username/>
     <maven.repo.password/>
 
-    <org.kie.server.user>yoda</org.kie.server.user>
-    <org.kie.server.pwd>usetheforce123@</org.kie.server.pwd>
-    <org.kie.workbench.user>adminUser</org.kie.workbench.user>
-    <org.kie.workbench.pwd>adminUser1!</org.kie.workbench.pwd>
-    <org.kie.server.controller.user>controllerUser</org.kie.server.controller.user>
-    <org.kie.server.controller.pwd>controllerUser1!</org.kie.server.controller.pwd>
-    <org.kie.workbench.maven.user>mavenUser</org.kie.workbench.maven.user>
-    <org.kie.workbench.maven.pwd>mavenUser1!</org.kie.workbench.maven.pwd>
+    <kie.app.user>adminUser</kie.app.user>
+    <kie.app.password>adminUser1!</kie.app.password>
+    <kie.app.credentials-secret-name>rhpam-credentials</kie.app.credentials-secret-name>
 
     <default.domain.suffix/>
 
@@ -281,14 +276,9 @@ $ keytool -import -alias client -keystore broker.ts -file client_cert -->
               <maven.repo.url>${maven.repo.url}</maven.repo.url>
               <maven.repo.username>${maven.repo.username}</maven.repo.username>
               <maven.repo.password>${maven.repo.password}</maven.repo.password>
-              <org.kie.server.user>${org.kie.server.user}</org.kie.server.user>
-              <org.kie.server.pwd>${org.kie.server.pwd}</org.kie.server.pwd>
-              <org.kie.workbench.user>${org.kie.workbench.user}</org.kie.workbench.user>
-              <org.kie.workbench.pwd>${org.kie.workbench.pwd}</org.kie.workbench.pwd>
-              <org.kie.workbench.maven.user>${org.kie.workbench.maven.user}</org.kie.workbench.maven.user>
-              <org.kie.workbench.maven.pwd>${org.kie.workbench.maven.pwd}</org.kie.workbench.maven.pwd>
-              <org.kie.server.controller.user>${org.kie.server.controller.user}</org.kie.server.controller.user>
-              <org.kie.server.controller.pwd>${org.kie.server.controller.pwd}</org.kie.server.controller.pwd>
+              <kie.app.user>${kie.app.user}</kie.app.user>
+              <kie.app.password>${kie.app.password}</kie.app.password>
+              <kie.app.credentials-secret-name>${kie.app.credentials-secret-name}</kie.app.credentials-secret-name>
               <default.domain.suffix>${default.domain.suffix}</default.domain.suffix>
               <amq.image.streams>${amq.image.streams}</amq.image.streams>
               <amq.username>${amq.username}</amq.username>

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -57,8 +57,8 @@
     <maven.repo.username/>
     <maven.repo.password/>
 
-    <kie.app.user>adminUser</kie.app.user>
-    <kie.app.password>adminUser1!</kie.app.password>
+    <kie.app.user>yoda</kie.app.user>
+    <kie.app.password>usetheforce123@</kie.app.password>
     <kie.app.credentials-secret-name>rhpam-credentials</kie.app.credentials-secret-name>
 
     <default.domain.suffix/>

--- a/test-cloud/test-cloud-remote/src/test/resources/test.properties
+++ b/test-cloud/test-cloud-remote/src/test/resources/test.properties
@@ -14,15 +14,9 @@ sso.service.username=serviceUser
 sso.service.password=serviceUser1!
 
 kie.app.name=myapp
-
-org.kie.server.user=yoda
-org.kie.server.pwd=usetheforce123@
-org.kie.workbench.user=adminUser
-org.kie.workbench.pwd=adminUser1!
-org.kie.server.controller.user=controllerUser
-org.kie.server.controller.pwd=controllerUser1!
-org.kie.workbench.maven.user=mavenUser
-org.kie.workbench.maven.pwd=mavenUser1!
+kie.app.user=adminUser
+kie.app.password=adminUser1!
+kie.app.credentials-secret-name=rhpam-credentials
 
 !-- Amq properties -->
 amq.image.streams=https://raw.githubusercontent.com/jboss-container-images/jboss-amq-7-broker-openshift-image/amq-broker-75-dev/amq-broker-7-image-streams.yaml

--- a/test-cloud/test-cloud-remote/src/test/resources/test.properties
+++ b/test-cloud/test-cloud-remote/src/test/resources/test.properties
@@ -14,8 +14,8 @@ sso.service.username=serviceUser
 sso.service.password=serviceUser1!
 
 kie.app.name=myapp
-kie.app.user=adminUser
-kie.app.password=adminUser1!
+kie.app.user=yoda
+kie.app.password=usetheforce123@
 kie.app.credentials-secret-name=rhpam-credentials
 
 !-- Amq properties -->


### PR DESCRIPTION
…Also, create a credentials secret name to setup the new user

update pom configuration

replace properties accordingly

Fix deployment for clusters

Reset CommonConfig.java

Changes after code review and reset common config

fix conflict

Revert ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioImpl

Code review: Rename method in Base64Utils

Use SecretBuilder instead

Remove unneeded configuration

Update framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl.java

Co-Authored-By: Jakub Schwan <jakubschwan@users.noreply.github.com>
Update framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java

Co-Authored-By: Jakub Schwan <jakubschwan@users.noreply.github.com>
Fixing the trial scenarios