### PR TITLE
BAQE-1261: Create dedicated GOGS instance for each Openshift project

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/GogsDeployment.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/GogsDeployment.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.api.deployment;
+
+/**
+ * Gogs deployment representation in cloud.
+ */
+public interface GogsDeployment extends Deployment {
+
+    /**
+     * Get URL for Gogs service (deployment).
+     *
+     * @return Docker URL
+     */
+    String getUrl();
+
+    /**
+     * @return get admin user to connect with Gogs instance.
+     */
+    String getUsername();
+
+    /**
+     * @return get admin password to connect with Gogs instance.
+     */
+    String getPassword();
+}

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/git/GitProvider.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/git/GitProvider.java
@@ -13,11 +13,13 @@
  * limitations under the License.
 */
 
-package org.kie.cloud.git;
+package org.kie.cloud.api.git;
 
-public interface GitProviderFactory {
+public interface GitProvider {
 
-    String providerType();
-    GitProvider createGitProvider();
-    void initGitConfigurationProperties();
+    String createGitRepository(String repositoryName, String repositoryPath);
+
+    void deleteGitRepository(String repositoryName);
+
+    String getRepositoryUrl(String repositoryName);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/git/GitProviderFactory.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/git/GitProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,17 +11,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
-package org.kie.cloud.provider.git;
+package org.kie.cloud.api.git;
 
-import org.kie.cloud.git.GitProvider;
-import org.kie.cloud.git.GitProviderService;
+public interface GitProviderFactory {
 
-public class Git {
-    private static final GitProvider gitProvider = new GitProviderService().createGitProvider();
+    String providerType();
 
-    public static GitProvider getProvider() {
-        return gitProvider;
+    GitProvider createGitProvider();
+
+    default void initGitConfigurationProperties() {
+
     }
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/EmployeeRosteringScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/EmployeeRosteringScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,8 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
+*/
 package org.kie.cloud.api.scenario;
 
 import org.kie.cloud.api.deployment.EmployeeRosteringDeployment;

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieDeploymentScenario.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/KieDeploymentScenario.java
@@ -17,10 +17,11 @@ package org.kie.cloud.api.scenario;
 
 import java.util.List;
 
+import org.kie.cloud.api.deployment.ControllerDeployment;
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
-import org.kie.cloud.api.deployment.ControllerDeployment;
+import org.kie.cloud.api.git.GitProvider;
 
 /**
  * Cloud deployment scenario representation.
@@ -62,4 +63,13 @@ public interface KieDeploymentScenario<T extends DeploymentScenario<T>> extends 
      * @see ControllerDeployment
      */
     List<ControllerDeployment> getControllerDeployments();
+
+    /**
+     * Return GIT provider.
+     *
+     * @return GIT provider.
+     */
+    default GitProvider getGitProvider() {
+        throw new RuntimeException("No GIT provider configured for this scenario");
+    }
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder.java
@@ -16,6 +16,7 @@
 package org.kie.cloud.api.scenario.builder;
 
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 
 public interface ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder extends DeploymentScenarioBuilder<ClusteredWorkbenchKieServerDatabasePersistentScenario> {
@@ -44,11 +45,20 @@ public interface ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder ex
     ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder deploySso();
 
     /**
-     * Return setup builder with an external LDAP.
+     * Return setup builder with additional GIT settings.
      *
-     * @param ldapSettings configuration of LDAP represented by a class.
+     * @param gitSettings settings configuration of GIT
      * @return Builder
      */
+    ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder withGitSettings(GitSettings gitSettings);
+
+    /**
+    *
+    * Return setup builder with an external LDAP.
+    *
+    * @param ldapSettings configuration of LDAP represented by a class.
+    * @return Builder
+    */
     ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder withExternalLdap(LdapSettings ldapSettings);
 
     /**
@@ -100,4 +110,5 @@ public interface ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder ex
      * @return Builder with configured memory limit.
      */
     ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder withWorkbenchMemoryLimit(String limit);
+
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/ImmutableKieServerAmqScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/ImmutableKieServerAmqScenarioBuilder.java
@@ -16,6 +16,7 @@
 package org.kie.cloud.api.scenario.builder;
 
 import org.kie.cloud.api.scenario.ImmutableKieServerAmqScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 
 public interface ImmutableKieServerAmqScenarioBuilder extends KieDeploymentScenarioBuilder<ImmutableKieServerAmqScenarioBuilder, ImmutableKieServerAmqScenario> {
@@ -46,24 +47,22 @@ public interface ImmutableKieServerAmqScenarioBuilder extends KieDeploymentScena
     /**
      * Return configured builder with Source location
      *
-     * @param gitRepoUrl Repository url.
      * @param gitReference Repository reference (branch/tag). E.g. 'master'.
      * @param gitContextDir Repository context (location of pom file).
      * @return Builder
      */
-    ImmutableKieServerAmqScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir);
+    ImmutableKieServerAmqScenarioBuilder withSourceLocation(String gitReference, String gitContextDir);
 
     /**
      * Return configured builder with Source location
      *
-     * @param gitRepoUrl Repository url.
      * @param gitReference Repository reference (branch/tag). E.g. 'master'.
      * @param gitContextDir Repository context (location of pom file).
      * @param artifactDirs Directories containing built kjars, separated by
      * commas. For example "usertask-project/target,signaltask-project/target".
      * @return Builder
      */
-    ImmutableKieServerAmqScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir, String artifactDirs);
+    ImmutableKieServerAmqScenarioBuilder withSourceLocation(String gitReference, String gitContextDir, String artifactDirs);
 
     /**
      * Return setup builder with additional configuration for SSO deployment.
@@ -114,4 +113,12 @@ public interface ImmutableKieServerAmqScenarioBuilder extends KieDeploymentScena
      * @return Builder with configured internal ldap.
      */
     ImmutableKieServerAmqScenarioBuilder withInternalLdap(LdapSettings ldapSettings);
+
+    /**
+     * Return setup builder with additional GIT settings.
+     *
+     * @param gitSettings settings configuration of GIT
+     * @return Builder
+     */
+    ImmutableKieServerAmqScenarioBuilder withGitSettings(GitSettings gitSettings);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/ImmutableKieServerScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/ImmutableKieServerScenarioBuilder.java
@@ -16,6 +16,7 @@
 package org.kie.cloud.api.scenario.builder;
 
 import org.kie.cloud.api.scenario.ImmutableKieServerScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 
 public interface ImmutableKieServerScenarioBuilder extends KieDeploymentScenarioBuilder<ImmutableKieServerScenarioBuilder, ImmutableKieServerScenario> {
@@ -46,24 +47,22 @@ public interface ImmutableKieServerScenarioBuilder extends KieDeploymentScenario
     /**
      * Return configured builder with Source location
      *
-     * @param gitRepoUrl Repository url.
      * @param gitReference Repository reference (branch/tag). E.g. 'master'.
      * @param gitContextDir Repository context (location of pom file).
      * @return Builder
      */
-    ImmutableKieServerScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir);
+    ImmutableKieServerScenarioBuilder withSourceLocation(String gitReference, String gitContextDir);
 
     /**
      * Return configured builder with Source location
      *
-     * @param gitRepoUrl Repository url.
      * @param gitReference Repository reference (branch/tag). E.g. 'master'.
      * @param gitContextDir Repository context (location of pom file).
      * @param artifactDirs Directories containing built kjars, separated by
      * commas. For example "usertask-project/target,signaltask-project/target".
      * @return Builder
      */
-    ImmutableKieServerScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir, String artifactDirs);
+    ImmutableKieServerScenarioBuilder withSourceLocation(String gitReference, String gitContextDir, String artifactDirs);
 
     /**
      * Return setup builder with additional configuration for SSO deployment.
@@ -114,4 +113,12 @@ public interface ImmutableKieServerScenarioBuilder extends KieDeploymentScenario
      * @return Builder with configured internal ldap.
      */
     ImmutableKieServerScenarioBuilder withInternalLdap(LdapSettings ldapSettings);
+
+    /**
+     * Return setup builder with additional GIT settings.
+     *
+     * @param gitSettings settings configuration of GIT
+     * @return Builder
+     */
+    ImmutableKieServerScenarioBuilder withGitSettings(GitSettings gitSettings);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchKieServerPersistentScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchKieServerPersistentScenarioBuilder.java
@@ -16,6 +16,7 @@
 package org.kie.cloud.api.scenario.builder;
 
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 
 public interface WorkbenchKieServerPersistentScenarioBuilder extends DeploymentScenarioBuilder<WorkbenchKieServerPersistentScenario> {
@@ -34,6 +35,14 @@ public interface WorkbenchKieServerPersistentScenarioBuilder extends DeploymentS
      * @return Builder
      */
     WorkbenchKieServerPersistentScenarioBuilder deploySso();
+
+    /**
+     * Return setup builder with additional GIT settings.
+     *
+     * @param gitSettings settings configuration of GIT
+     * @return Builder
+     */
+    WorkbenchKieServerPersistentScenarioBuilder withGitSettings(GitSettings gitSettings);
 
     /**
      * @param kieServerId kie-server id

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchKieServerScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchKieServerScenarioBuilder.java
@@ -18,6 +18,7 @@ package org.kie.cloud.api.scenario.builder;
 import java.time.Duration;
 
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
+import org.kie.cloud.api.settings.GitSettings;
 
 /**
  * Cloud builder for Workbench and Kie Server in project. Built setup
@@ -28,9 +29,9 @@ public interface WorkbenchKieServerScenarioBuilder extends DeploymentScenarioBui
 
     /**
      * Return setup builder with additional configuration of internal maven repo.
-     * 
+     *
      * Parameters will be used automatically
-     * 
+     *
      * @return Builder with configured internal maven repo.
      */
     WorkbenchKieServerScenarioBuilder withInternalMavenRepo();
@@ -75,4 +76,12 @@ public interface WorkbenchKieServerScenarioBuilder extends DeploymentScenarioBui
      * @return Builder with Prometheus monitoring configured monitoring deployed Kie servers.
      */
     WorkbenchKieServerScenarioBuilder withPrometheusMonitoring();
+
+    /**
+     * Return setup builder with additional GIT settings.
+     *
+     * @param gitSettings settings configuration of GIT
+     * @return Builder
+     */
+    WorkbenchKieServerScenarioBuilder withGitSettings(GitSettings gitSettings);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder.java
@@ -16,9 +16,11 @@
 package org.kie.cloud.api.scenario.builder;
 
 import org.kie.cloud.api.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 
-public interface WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder extends KieDeploymentScenarioBuilder<WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder, WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenario> {
+public interface WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder extends
+                                                                                             KieDeploymentScenarioBuilder<WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder, WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenario> {
 
     /**
      * Return setup builder with additional configuration of internal maven repo.
@@ -46,24 +48,22 @@ public interface WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseSce
     /**
      * Return configured builder with Source location
      *
-     * @param gitRepoUrl Repository url.
      * @param gitReference Repository reference (branch/tag). E.g. 'master'.
      * @param gitContextDir Repository context (location of pom file).
      * @return Builder
      */
-    WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir);
+    WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder withSourceLocation(String gitReference, String gitContextDir);
 
     /**
      * Return configured builder with Source location
      *
-     * @param gitRepoUrl Repository url.
      * @param gitReference Repository reference (branch/tag). E.g. 'master'.
      * @param gitContextDir Repository context (location of pom file).
      * @param artifactDirs Directories containing built kjars, separated by
      * commas. For example "usertask-project/target,signaltask-project/target".
      * @return Builder
      */
-    WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir, String artifactDirs);
+    WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder withSourceLocation(String gitReference, String gitContextDir, String artifactDirs);
 
     /**
      * Return setup builder with additional configuration for SSO deployment.
@@ -122,5 +122,13 @@ public interface WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseSce
     *
     * @return Builder
     */
-   WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder enableExternalJmsSignalQueue(String queueJndiName);
+    WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder enableExternalJmsSignalQueue(String queueJndiName);
+
+    /**
+     * Return setup builder with additional GIT settings.
+     *
+     * @param gitSettings settings configuration of GIT
+     * @return Builder
+     */
+    WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder withGitSettings(GitSettings gitSettings);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder.java
@@ -18,9 +18,11 @@ package org.kie.cloud.api.scenario.builder;
 import java.time.Duration;
 
 import org.kie.cloud.api.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 
-public interface WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder extends KieDeploymentScenarioBuilder<WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder, WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario> {
+public interface WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder extends
+                                                                                          KieDeploymentScenarioBuilder<WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder, WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario> {
 
     /**
      * Return setup builder with additional configuration of internal maven repo.
@@ -48,24 +50,22 @@ public interface WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenar
     /**
      * Return configured builder with Source location
      *
-     * @param gitRepoUrl Repository url.
      * @param gitReference Repository reference (branch/tag). E.g. 'master'.
      * @param gitContextDir Repository context (location of pom file).
      * @return Builder
      */
-    WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir);
+    WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withSourceLocation(String gitReference, String gitContextDir);
 
     /**
      * Return configured builder with Source location
      *
-     * @param gitRepoUrl Repository url.
      * @param gitReference Repository reference (branch/tag). E.g. 'master'.
      * @param gitContextDir Repository context (location of pom file).
      * @param artifactDirs Directories containing built kjars, separated by
      * commas. For example "usertask-project/target,signaltask-project/target".
      * @return Builder
      */
-    WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir, String artifactDirs);
+    WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withSourceLocation(String gitReference, String gitContextDir, String artifactDirs);
 
     /**
      * Return setup builder with additional configuration for SSO deployment.
@@ -132,4 +132,12 @@ public interface WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenar
      * @return Builder with configured memory limit.
      */
     WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withKieServerMemoryLimit(String limit);
+
+    /**
+     * Return setup builder with additional GIT settings.
+     *
+     * @param gitSettings settings configuration of GIT
+     * @return Builder
+     */
+    WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withGitSettings(GitSettings gitSettings);
 }

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/GitSettings.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/settings/GitSettings.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.api.settings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Class to configure the GIT instance to be used among the tests.
+ *
+ * Currently, there is only one way to create the GitSettings via properties (see method .fromProperties()).
+ */
+public class GitSettings {
+
+    public static final String GIT_PROVIDER = "git.provider";
+
+    private final String provider;
+    private List<Consumer<String>> repositoryLoadedActions = new ArrayList<>();
+    private String repositoryName;
+    private String repositoryPath;
+
+    public GitSettings(String provider) {
+        this.provider = provider;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public String getRepositoryName() {
+        return repositoryName;
+    }
+
+    public String getRepositoryPath() {
+        return repositoryPath;
+    }
+
+    public List<Consumer<String>> getRepositoryLoadedActions() {
+        return repositoryLoadedActions;
+    }
+
+    public GitSettings withRepository(String repositoryName, String repositoryPath) {
+        this.repositoryName = repositoryName;
+        this.repositoryPath = repositoryPath;
+        return this;
+    }
+
+    /**
+     * Suscribe until the repository URL is loaded and then fire the repositoryLoadedAction action.
+     *
+     * @param repositoryLoadedAction action to use the repository URL.
+     */
+    public void addOnRepositoryLoaded(Consumer<String> repositoryLoadedAction) {
+        if (this.repositoryName == null) {
+            throw new RuntimeException("Repository name not configured");
+        }
+
+        repositoryLoadedActions.add(repositoryLoadedAction);
+    }
+
+    public static final GitSettings fromProperties() {
+        return new GitSettings(System.getProperty(GIT_PROVIDER));
+    }
+
+}

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/AbstractGitProvider.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/AbstractGitProvider.java
@@ -17,7 +17,6 @@ package org.kie.cloud.git;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
@@ -26,19 +25,13 @@ import org.eclipse.jgit.api.RemoteRemoveCommand;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.kie.cloud.api.git.GitProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class AbstractGitProvider implements GitProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractGitProvider.class);
-
-    protected String generateRepositoryName(String repositoryPrefixName) {
-        final String repositoryName = repositoryPrefixName + "-" + UUID.randomUUID().toString().substring(0, 4);
-        logger.debug("Repository name {} was generated", repositoryName);
-
-        return repositoryName;
-    }
 
     protected void pushToGitRepository(String httpUrl, String repositoryPath,
             String username, String password) {

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/constants/GitConstants.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/constants/GitConstants.java
@@ -16,13 +16,12 @@
 package org.kie.cloud.git.constants;
 
 import org.kie.cloud.api.constants.Constants;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.git.GitProviderService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GitConstants implements Constants {
-
-    public static final String GIT_PROVIDER = "git.provider";
 
     public static final String GITHUB_USER = "github.username";
     public static final String GITHUB_PASSWORD = "github.password";
@@ -34,7 +33,7 @@ public class GitConstants implements Constants {
     private static final Logger logger = LoggerFactory.getLogger(GitConstants.class);
 
     public static String getGitProvider() {
-        return System.getProperty(GIT_PROVIDER);
+        return System.getProperty(GitSettings.GIT_PROVIDER);
     }
 
     public static String getGitHubUser() {

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/github/GitHubGitProvider.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/github/GitHubGitProvider.java
@@ -37,8 +37,7 @@ public class GitHubGitProvider extends AbstractGitProvider {
     }
 
     @Override
-    public String createGitRepositoryWithPrefix(String repositoryPrefixName, String repositoryPath) {
-        String repositoryName = generateRepositoryName(repositoryPrefixName);
+    public String createGitRepository(String repositoryName, String repositoryPath) {
 
         try {
             RepositoryService service = new RepositoryService(client);

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/github/GitHubGitProviderFactory.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/github/GitHubGitProviderFactory.java
@@ -15,17 +15,19 @@
 
 package org.kie.cloud.git.github;
 
-import org.kie.cloud.git.GitProvider;
-import org.kie.cloud.git.GitProviderFactory;
+import org.kie.cloud.api.git.GitProvider;
+import org.kie.cloud.api.git.GitProviderFactory;
 import org.kie.cloud.git.constants.GitConstants;
 
 public class GitHubGitProviderFactory implements GitProviderFactory {
 
-    @Override public String providerType() {
+    @Override
+    public String providerType() {
         return "GitHub";
     }
 
-    @Override public GitProvider createGitProvider() {
+    @Override
+    public GitProvider createGitProvider() {
         final String user = GitConstants.readMandatoryParameter(GitConstants.GITHUB_USER);
         final String password = GitConstants.readMandatoryParameter(GitConstants.GITHUB_PASSWORD);
 

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/gogs/GogsGitProvider.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/gogs/GogsGitProvider.java
@@ -19,12 +19,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
+import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 import org.kie.cloud.git.AbstractGitProvider;
-import org.apache.http.client.fluent.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,8 +48,8 @@ public class GogsGitProvider extends AbstractGitProvider {
         this.password = password;
     }
 
-    @Override public String createGitRepositoryWithPrefix(String repositoryPrefixName, String repositoryPath) {
-        final String repositoryName = generateRepositoryName(repositoryPrefixName);
+    @Override
+    public String createGitRepository(String repositoryName, String repositoryPath) {
         createRepository(repositoryName);
         pushToGitRepository(getRepositoryUrl(repositoryName), repositoryPath,
                 user, password);
@@ -56,7 +57,8 @@ public class GogsGitProvider extends AbstractGitProvider {
         return repositoryName;
     }
 
-    @Override public synchronized void deleteGitRepository(String repositoryName) {
+    @Override
+    public synchronized void deleteGitRepository(String repositoryName) {
         try {
             final StatusLine statusLine = Request.Delete(deleteRepositoryUrl(repositoryName))
                     .addHeader(HttpHeaders.AUTHORIZATION, authHeaderValue())
@@ -74,7 +76,8 @@ public class GogsGitProvider extends AbstractGitProvider {
         }
     }
 
-    @Override public String getRepositoryUrl(String repositoryName) {
+    @Override
+    public String getRepositoryUrl(String repositoryName) {
         try {
             URL repositoryUrl = new URL(url);
             repositoryUrl = new URL(repositoryUrl, user + "/");

--- a/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/gogs/GogsGitProviderFactory.java
+++ b/framework-cloud/framework-git/src/main/java/org/kie/cloud/git/gogs/GogsGitProviderFactory.java
@@ -15,17 +15,19 @@
 
 package org.kie.cloud.git.gogs;
 
-import org.kie.cloud.git.GitProvider;
-import org.kie.cloud.git.GitProviderFactory;
+import org.kie.cloud.api.git.GitProvider;
+import org.kie.cloud.api.git.GitProviderFactory;
 import org.kie.cloud.git.constants.GitConstants;
 
 public class GogsGitProviderFactory implements GitProviderFactory {
 
-    @Override public String providerType() {
-        return "Gogs";
+    @Override
+    public String providerType() {
+        return "ExternalGogs";
     }
 
-    @Override public GitProvider createGitProvider() {
+    @Override
+    public GitProvider createGitProvider() {
         final String url = GitConstants.readMandatoryParameter(GitConstants.GOGS_URL);
         final String username = GitConstants.readMandatoryParameter(GitConstants.GOGS_USER);
         final String password = GitConstants.readMandatoryParameter(GitConstants.GOGS_PASSWORD);
@@ -33,7 +35,8 @@ public class GogsGitProviderFactory implements GitProviderFactory {
         return new GogsGitProvider(url, username, password);
     }
 
-    @Override public void initGitConfigurationProperties() {
+    @Override
+    public void initGitConfigurationProperties() {
         GitConstants.verifySystemPropertyIsSet(GitConstants.GOGS_URL);
         GitConstants.verifySystemPropertyIsSet(GitConstants.GOGS_USER);
         GitConstants.verifySystemPropertyIsSet(GitConstants.GOGS_PASSWORD);

--- a/framework-cloud/framework-git/src/main/resources/META-INF/services/org.kie.cloud.api.git.GitProviderFactory
+++ b/framework-cloud/framework-git/src/main/resources/META-INF/services/org.kie.cloud.api.git.GitProviderFactory
@@ -1,0 +1,2 @@
+org.kie.cloud.git.github.GitHubGitProviderFactory
+org.kie.cloud.git.gogs.GogsGitProviderFactory

--- a/framework-cloud/framework-git/src/test/java/org/kie/cloud/git/GitProviderServiceTest.java
+++ b/framework-cloud/framework-git/src/test/java/org/kie/cloud/git/GitProviderServiceTest.java
@@ -17,6 +17,7 @@ package org.kie.cloud.git;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.git.constants.GitConstants;
 import org.kie.cloud.git.github.GitHubGitProvider;
 
@@ -40,26 +41,26 @@ public class GitProviderServiceTest {
 
     @Test
     public void testGetNotFoundGitProvider() {
-        System.setProperty(GitConstants.GIT_PROVIDER, "not-existing-provider");
+        System.setProperty(GitSettings.GIT_PROVIDER, "not-existing-provider");
 
         try {
             Throwable thrown = catchThrowable(() -> gitProviderService.createGitProvider());
             assertThat(thrown).isInstanceOf(RuntimeException.class).hasMessageContaining("Unknown type of Git provider not-existing-provider");
         } finally {
-            System.clearProperty(GitConstants.GIT_PROVIDER);
+            System.clearProperty(GitSettings.GIT_PROVIDER);
         }
     }
 
     @Test
     public void testGetGitHubGitProvider() {
-        System.setProperty(GitConstants.GIT_PROVIDER, "GitHub");
+        System.setProperty(GitSettings.GIT_PROVIDER, "GitHub");
         System.setProperty(GitConstants.GITHUB_USER, "GitHubUser");
         System.setProperty(GitConstants.GITHUB_PASSWORD, "GitHubPass");
 
         try {
             assertThat(gitProviderService.createGitProvider()).isInstanceOf(GitHubGitProvider.class);
         } finally {
-            System.clearProperty(GitConstants.GIT_PROVIDER);
+            System.clearProperty(GitSettings.GIT_PROVIDER);
             System.clearProperty(GitConstants.GITHUB_USER);
             System.clearProperty(GitConstants.GITHUB_PASSWORD);
         }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioApb.java
@@ -30,6 +30,7 @@ import org.kie.cloud.api.deployment.PrometheusDeployment;
 import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.openshift.constants.ApbConstants;
@@ -40,6 +41,7 @@ import org.kie.cloud.openshift.deployment.WorkbenchDeploymentImpl;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment;
 import org.kie.cloud.openshift.deployment.external.ExternalDeploymentApb;
 import org.kie.cloud.openshift.util.ApbImageGetter;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.PrometheusDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,16 +50,17 @@ public class WorkbenchKieServerScenarioApb extends OpenShiftScenario<WorkbenchKi
 
     private WorkbenchDeploymentImpl workbenchDeployment;
     private KieServerDeploymentImpl kieServerDeployment;
-    private boolean deployPrometheus;
+    private final ScenarioRequest request;
     private PrometheusDeployment prometheusDeployment;
+    private GitProvider gitProvider;
 
     private Map<String, String> extraVars;
 
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchKieServerScenarioApb.class);
 
-    public WorkbenchKieServerScenarioApb(Map<String, String> extraVars, boolean deployPrometheus) {
+    public WorkbenchKieServerScenarioApb(Map<String, String> extraVars, ScenarioRequest request) {
         this.extraVars = extraVars;
-        this.deployPrometheus = deployPrometheus;
+        this.request = request;
     }
 
     @Override
@@ -80,8 +83,12 @@ public class WorkbenchKieServerScenarioApb extends OpenShiftScenario<WorkbenchKi
         kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
         kieServerDeployment.setPassword(ApbConstants.DefaultUser.PASSWORD);
 
-        if (deployPrometheus) {
+        if (request.isDeployPrometheus()) {
             prometheusDeployment = PrometheusDeployer.deploy(project, kieServerDeployment);
+        }
+
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
         }
 
         logger.info("Waiting for Workbench deployment to become ready.");
@@ -165,5 +172,10 @@ public class WorkbenchKieServerScenarioApb extends OpenShiftScenario<WorkbenchKi
     @Override
     public Optional<PrometheusDeployment> getPrometheusDeployment() {
         return Optional.ofNullable(prometheusDeployment);
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioApb.java
@@ -30,6 +30,7 @@ import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
 import org.kie.cloud.api.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenario;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
@@ -43,6 +44,7 @@ import org.kie.cloud.openshift.resource.Project;
 import org.kie.cloud.openshift.util.AmqImageStreamDeployer;
 import org.kie.cloud.openshift.util.AmqSecretDeployer;
 import org.kie.cloud.openshift.util.ApbImageGetter;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.SsoDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,21 +56,22 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScena
     private DatabaseDeploymentImpl databaseDeployment;
     private SsoDeployment ssoDeployment;
     private AmqDeploymentImpl amqDeployment;
+    private GitProvider gitProvider;
 
-    private boolean deploySso;
+    private final ScenarioRequest request;
 
     private static final Logger logger = LoggerFactory.getLogger(KieServerWithExternalDatabaseScenario.class);
 
     private Map<String, String> extraVars;
 
-    public WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioApb(Map<String, String> extraVars, boolean deploySso) {
+    public WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioApb(Map<String, String> extraVars, ScenarioRequest request) {
         this.extraVars = extraVars;
-        this.deploySso = deploySso;
+        this.request = request;
     }
 
     @Override
     protected void deployKieDeployments() {
-        if (deploySso) {
+        if (request.isDeploySso()) {
             logger.warn("SSO is configured for this test scenario. Kie Server SSO client can be set only for one Kie Server. For more deploymets it mus be configured manually.");
             ssoDeployment = SsoDeployer.deploy(project);
 
@@ -79,6 +82,10 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScena
             extraVars.put(OpenShiftApbConstants.KIE_SERVER_SSO_SECRET, "kie-server-secret");
 
             extraVars.put(OpenShiftApbConstants.SSO_PRINCIPAL_ATTRIBUTE, "preferred_username");
+        }
+
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
         }
 
         logger.info("Creating trusted secret");
@@ -197,6 +204,11 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScena
     @Override
     public AmqDeployment getAmqDeployment() {
         return amqDeployment;
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 
     private KieServerDeploymentImpl createKieServerDeployment(Project project) {

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderApb.java
@@ -21,12 +21,14 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.api.scenario.builder.WorkbenchKieServerPersistentScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.openshift.constants.ApbConstants;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.constants.ProjectApbSpecificPropertyNames;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 import org.kie.cloud.openshift.scenario.WorkbenchKieServerPersistentScenarioApb;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +37,7 @@ public class WorkbenchKieServerPersistentScenarioBuilderApb extends AbstractOpen
 
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchKieServerPersistentScenarioBuilderApb.class);
     private final Map<String, String> extraVars = new HashMap<>();
-    private boolean deploySSO = false;
+    private final ScenarioRequest request = new ScenarioRequest();
     private final ProjectApbSpecificPropertyNames propertyNames = ProjectApbSpecificPropertyNames.create();
 
     public WorkbenchKieServerPersistentScenarioBuilderApb() {
@@ -54,7 +56,7 @@ public class WorkbenchKieServerPersistentScenarioBuilderApb extends AbstractOpen
 
     @Override
     public WorkbenchKieServerPersistentScenario getDeploymentScenarioInstance() {
-        return new WorkbenchKieServerPersistentScenarioApb(extraVars, deploySSO);
+        return new WorkbenchKieServerPersistentScenarioApb(extraVars, request);
     }
 
     @Override
@@ -65,9 +67,15 @@ public class WorkbenchKieServerPersistentScenarioBuilderApb extends AbstractOpen
 
     @Override
     public WorkbenchKieServerPersistentScenarioBuilder deploySso() {
-        deploySSO = true;
+        request.enableDeploySso();
         extraVars.put(OpenShiftApbConstants.SSO_USER, DeploymentConstants.getSsoServiceUser());
         extraVars.put(OpenShiftApbConstants.SSO_PWD, DeploymentConstants.getSsoServicePassword());
+        return this;
+    }
+
+    @Override
+    public WorkbenchKieServerPersistentScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerScenarioBuilderApb.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerScenarioBuilderApb.java
@@ -22,16 +22,18 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.api.scenario.builder.WorkbenchKieServerScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.openshift.constants.ApbConstants;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 import org.kie.cloud.openshift.scenario.WorkbenchKieServerScenarioApb;
 
 public class WorkbenchKieServerScenarioBuilderApb extends AbstractOpenshiftScenarioBuilderApb<WorkbenchKieServerScenario> implements WorkbenchKieServerScenarioBuilder {
 
     private final Map<String, String> extraVars = new HashMap<>();
-    private boolean deployPrometheus = false;
+    private ScenarioRequest request = new ScenarioRequest();
 
     public WorkbenchKieServerScenarioBuilderApb() {
         extraVars.put(OpenShiftApbConstants.APB_PLAN_ID, ApbConstants.Plans.TRIAL);
@@ -43,7 +45,7 @@ public class WorkbenchKieServerScenarioBuilderApb extends AbstractOpenshiftScena
 
     @Override
     public WorkbenchKieServerScenario getDeploymentScenarioInstance() {
-        return new WorkbenchKieServerScenarioApb(extraVars, deployPrometheus);
+        return new WorkbenchKieServerScenarioApb(extraVars, request);
 
     }
 
@@ -85,8 +87,14 @@ public class WorkbenchKieServerScenarioBuilderApb extends AbstractOpenshiftScena
 
     @Override
     public WorkbenchKieServerScenarioBuilder withPrometheusMonitoring() {
-        deployPrometheus = true;
+        request.enableDeployPrometheus();
         extraVars.put(OpenShiftApbConstants.PROMETHEUS_SERVER_EXT_DISABLED, "false");
+        return this;
+    }
+
+    @Override
+    public WorkbenchKieServerScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ImmutableKieServerAmqScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ImmutableKieServerAmqScenarioImpl.java
@@ -33,6 +33,7 @@ import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.ImmutableKieServerAmqScenario;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.deployment.AmqDeploymentImpl;
@@ -42,8 +43,10 @@ import org.kie.cloud.openshift.operator.model.KieApp;
 import org.kie.cloud.openshift.operator.model.components.Auth;
 import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.model.components.Sso;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 import org.kie.cloud.openshift.util.AmqImageStreamDeployer;
 import org.kie.cloud.openshift.util.AmqSecretDeployer;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.SsoDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,20 +54,22 @@ import org.slf4j.LoggerFactory;
 public class ImmutableKieServerAmqScenarioImpl extends OpenShiftOperatorScenario<ImmutableKieServerAmqScenario> implements ImmutableKieServerAmqScenario {
 
     private KieServerDeploymentImpl kieServerDeployment;
-    private boolean deploySso;
     private SsoDeployment ssoDeployment;
     private AmqDeploymentImpl amqDeployment;
+    private GitProvider gitProvider;
+
+    private final ScenarioRequest request;
 
     private static final Logger logger = LoggerFactory.getLogger(ImmutableKieServerAmqScenarioImpl.class);
 
-    public ImmutableKieServerAmqScenarioImpl(KieApp kieApp, boolean deploySso) {
+    public ImmutableKieServerAmqScenarioImpl(KieApp kieApp, ScenarioRequest request) {
         super(kieApp);
-        this.deploySso = deploySso;
+        this.request = request;
     }
 
     @Override
     protected void deployCustomResource() {
-        if (deploySso) {
+        if (request.isDeploySso()) {
             ssoDeployment = SsoDeployer.deploySecure(project);
             URL ssoSecureUrl = ssoDeployment.getSecureUrl().orElseThrow(() -> new RuntimeException("RH SSO secure URL not found."));
 
@@ -78,6 +83,10 @@ public class ImmutableKieServerAmqScenarioImpl extends OpenShiftOperatorScenario
             Auth auth = new Auth();
             auth.setSso(sso);
             kieApp.getSpec().setAuth(auth);
+        }
+
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
         }
 
         for (Server server : kieApp.getSpec().getObjects().getServers()) {
@@ -161,5 +170,10 @@ public class ImmutableKieServerAmqScenarioImpl extends OpenShiftOperatorScenario
     @Override
     public AmqDeployment getAmqDeployment() {
         return amqDeployment;
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ImmutableKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/ImmutableKieServerScenarioImpl.java
@@ -32,6 +32,7 @@ import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.ImmutableKieServerScenario;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.deployment.KieServerDeploymentImpl;
@@ -40,6 +41,8 @@ import org.kie.cloud.openshift.operator.model.KieApp;
 import org.kie.cloud.openshift.operator.model.components.Auth;
 import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.model.components.Sso;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.SsoDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,19 +50,20 @@ import org.slf4j.LoggerFactory;
 public class ImmutableKieServerScenarioImpl extends OpenShiftOperatorScenario<ImmutableKieServerScenario> implements ImmutableKieServerScenario {
 
     private KieServerDeploymentImpl kieServerDeployment;
-    private boolean deploySso;
+    private final ScenarioRequest request;
     private SsoDeployment ssoDeployment;
+    private GitProvider gitProvider;
 
     private static final Logger logger = LoggerFactory.getLogger(ImmutableKieServerScenarioImpl.class);
 
-    public ImmutableKieServerScenarioImpl(KieApp kieApp, boolean deploySso) {
+    public ImmutableKieServerScenarioImpl(KieApp kieApp, ScenarioRequest request) {
         super(kieApp);
-        this.deploySso = deploySso;
+        this.request = request;
     }
 
     @Override
     protected void deployCustomResource() {
-        if (deploySso) {
+        if (request.isDeploySso()) {
             ssoDeployment = SsoDeployer.deploySecure(project);
             URL ssoSecureUrl = ssoDeployment.getSecureUrl().orElseThrow(() -> new RuntimeException("RH SSO secure URL not found."));
 
@@ -73,6 +77,10 @@ public class ImmutableKieServerScenarioImpl extends OpenShiftOperatorScenario<Im
             Auth auth = new Auth();
             auth.setSso(sso);
             kieApp.getSpec().setAuth(auth);
+        }
+
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
         }
 
         for (Server server : kieApp.getSpec().getObjects().getServers()) {
@@ -136,5 +144,10 @@ public class ImmutableKieServerScenarioImpl extends OpenShiftOperatorScenario<Im
     @Override
     public SsoDeployment getSsoDeployment() {
         return ssoDeployment;
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchKieServerScenarioImpl.java
@@ -33,6 +33,7 @@ import org.kie.cloud.api.deployment.PrometheusDeployment;
 import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -41,6 +42,8 @@ import org.kie.cloud.openshift.deployment.WorkbenchDeploymentImpl;
 import org.kie.cloud.openshift.operator.deployment.KieServerOperatorDeployment;
 import org.kie.cloud.openshift.operator.deployment.WorkbenchOperatorDeployment;
 import org.kie.cloud.openshift.operator.model.KieApp;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.PrometheusDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,14 +52,15 @@ public class WorkbenchKieServerScenarioImpl extends OpenShiftOperatorScenario<Wo
 
     private WorkbenchDeploymentImpl workbenchDeployment;
     private KieServerDeploymentImpl kieServerDeployment;
-    private boolean deployPrometheus;
+    private final ScenarioRequest request;
     private PrometheusDeployment prometheusDeployment;
+    private GitProvider gitProvider;
 
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchKieServerScenarioImpl.class);
 
-    public WorkbenchKieServerScenarioImpl(KieApp kieApp, boolean deployPrometheus) {
+    public WorkbenchKieServerScenarioImpl(KieApp kieApp, ScenarioRequest request) {
         super(kieApp);
-        this.deployPrometheus = deployPrometheus;
+        this.request = request;
     }
 
     @Override
@@ -74,8 +78,12 @@ public class WorkbenchKieServerScenarioImpl extends OpenShiftOperatorScenario<Wo
         kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
         kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
 
-        if (deployPrometheus) {
+        if (request.isDeployPrometheus()) {
             prometheusDeployment = PrometheusDeployer.deployAsOperator(project, kieServerDeployment);
+        }
+
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
         }
 
         logger.info("Waiting until all services are created.");
@@ -152,5 +160,10 @@ public class WorkbenchKieServerScenarioImpl extends OpenShiftOperatorScenario<Wo
     @Override
     public Optional<PrometheusDeployment> getPrometheusDeployment() {
         return Optional.ofNullable(prometheusDeployment);
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioImpl.java
@@ -35,6 +35,7 @@ import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenario;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -48,8 +49,10 @@ import org.kie.cloud.openshift.operator.model.KieApp;
 import org.kie.cloud.openshift.operator.model.components.Auth;
 import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.model.components.Sso;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 import org.kie.cloud.openshift.util.AmqImageStreamDeployer;
 import org.kie.cloud.openshift.util.AmqSecretDeployer;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.SsoDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,19 +65,20 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenari
     private DatabaseDeploymentImpl databaseDeployment;
     private SsoDeployment ssoDeployment;
     private AmqDeploymentImpl amqDeployment;
-    private boolean deploySso;
+    private GitProvider gitProvider;
+    private final ScenarioRequest request;
 
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioImpl.class);
 
-    public WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioImpl(KieApp kieApp, boolean deploySso) {
+    public WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioImpl(KieApp kieApp, ScenarioRequest request) {
         super(kieApp);
-        this.deploySso = deploySso;
+        this.request = request;
     }
 
     @Override
     protected void deployCustomResource() {
 
-        if (deploySso) {
+        if (request.isDeploySso()) {
             ssoDeployment = SsoDeployer.deploySecure(project);
             URL ssoSecureUrl = ssoDeployment.getSecureUrl().orElseThrow(() -> new RuntimeException("RH SSO secure URL not found."));
 
@@ -90,7 +94,12 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenari
             kieApp.getSpec().setAuth(auth);
         }
 
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
+        }
+
         registerTrustedSecret(kieApp.getSpec().getObjects().getConsole());
+
         for (Server server : kieApp.getSpec().getObjects().getServers()) {
             registerTrustedSecret(server);
         }
@@ -218,5 +227,10 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenari
     @Override
     public AmqDeployment getAmqDeployment() {
         return amqDeployment;
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl.java
@@ -34,6 +34,7 @@ import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -46,6 +47,8 @@ import org.kie.cloud.openshift.operator.model.KieApp;
 import org.kie.cloud.openshift.operator.model.components.Auth;
 import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.model.components.Sso;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.SsoDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,19 +60,20 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioIm
     private KieServerDeploymentImpl kieServerDeployment;
     private DatabaseDeploymentImpl databaseDeployment;
     private SsoDeployment ssoDeployment;
-    private boolean deploySso;
+    private GitProvider gitProvider;
+    private final ScenarioRequest request;
 
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl.class);
 
-    public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl(KieApp kieApp, boolean deploySso) {
+    public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl(KieApp kieApp, ScenarioRequest request) {
         super(kieApp);
-        this.deploySso = deploySso;
+        this.request = request;
     }
 
     @Override
     protected void deployCustomResource() {
 
-        if (deploySso) {
+        if (request.isDeploySso()) {
             ssoDeployment = SsoDeployer.deploySecure(project);
             URL ssoSecureUrl = ssoDeployment.getSecureUrl().orElseThrow(() -> new RuntimeException("RH SSO secure URL not found."));
 
@@ -85,7 +89,12 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioIm
             kieApp.getSpec().setAuth(auth);
         }
 
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
+        }
+
         registerTrustedSecret(kieApp.getSpec().getObjects().getConsole());
+
         for (Server server : kieApp.getSpec().getObjects().getServers()) {
             registerTrustedSecret(server);
         }
@@ -193,5 +202,10 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioIm
     @Override
     public SsoDeployment getSsoDeployment() {
         return ssoDeployment;
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.openshift.constants.ImageEnvVariables;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -38,13 +39,14 @@ import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 import org.kie.cloud.openshift.template.ProjectProfile;
 
 public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<ClusteredWorkbenchKieServerDatabasePersistentScenario> implements
                                                                               ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder {
 
     private KieApp kieApp = new KieApp();
-    private boolean deploySSO = false;
+    private final ScenarioRequest request = new ScenarioRequest();
 
     public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl() {
         isScenarioAllowed();
@@ -83,7 +85,7 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
 
     @Override
     public ClusteredWorkbenchKieServerDatabasePersistentScenario getDeploymentScenarioInstance() {
-        return new ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl(kieApp, deploySSO);
+        return new ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl(kieApp, request);
     }
 
     @Override
@@ -100,7 +102,7 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
 
     @Override
     public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder deploySso() {
-        deploySSO = true;
+        request.enableDeploySso();
         SsoClient ssoClient = new SsoClient();
         ssoClient.setName("workbench-client");
         ssoClient.setSecret("workbench-secret");
@@ -113,6 +115,12 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
             ssoClient.setSecret("kie-server-" + i + "-secret");
             servers[i].setSsoClient(ssoClient);
         }
+        return this;
+    }
+
+    @Override
+    public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerAmqScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerAmqScenarioBuilderImpl.java
@@ -22,6 +22,7 @@ import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.DeploymentScenarioListener;
 import org.kie.cloud.api.scenario.ImmutableKieServerAmqScenario;
 import org.kie.cloud.api.scenario.builder.ImmutableKieServerAmqScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.openshift.constants.ImageEnvVariables;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -41,12 +42,13 @@ import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.ImmutableKieServerAmqScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 import org.kie.cloud.openshift.template.ProjectProfile;
 
 public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<ImmutableKieServerAmqScenario> implements ImmutableKieServerAmqScenarioBuilder {
 
     private KieApp kieApp = new KieApp();
-    private boolean deploySSO = false;
+    private ScenarioRequest request = new ScenarioRequest();
 
     public ImmutableKieServerAmqScenarioBuilderImpl() {
         isScenarioAllowed();
@@ -90,7 +92,7 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftS
 
     @Override
     public ImmutableKieServerAmqScenario getDeploymentScenarioInstance() {
-        return new ImmutableKieServerAmqScenarioImpl(kieApp, deploySSO);
+        return new ImmutableKieServerAmqScenarioImpl(kieApp, request);
     }
 
     @Override
@@ -101,7 +103,7 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftS
 
     @Override
     public ImmutableKieServerAmqScenarioBuilder deploySso() {
-        deploySSO = true;
+        request.enableDeploySso();
         Server[] servers = kieApp.getSpec().getObjects().getServers();
         for (int i = 0; i < servers.length; i++) {
             SsoClient ssoClient = new SsoClient();
@@ -109,6 +111,12 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftS
             ssoClient.setSecret("kie-server-" + i + "-secret");
             servers[i].setSsoClient(ssoClient);
         }
+        return this;
+    }
+
+    @Override
+    public ImmutableKieServerAmqScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 
@@ -169,11 +177,15 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftS
     }
 
     @Override
-    public ImmutableKieServerAmqScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir) {
+    public ImmutableKieServerAmqScenarioBuilder withSourceLocation(String gitReference, String gitContextDir) {
+        if (request.getGitSettings() == null) {
+            throw new RuntimeException("Need to configure the git settings first");
+        }
+
         GitSource gitSource = new GitSource();
         gitSource.setContextDir(gitContextDir);
         gitSource.setReference(gitReference);
-        gitSource.setUri(gitRepoUrl);
+        request.getGitSettings().addOnRepositoryLoaded(gitSource::setUri);
 
         for (Server server : kieApp.getSpec().getObjects().getServers()) {
             if (server.getBuild() == null) {
@@ -186,8 +198,8 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftS
     }
 
     @Override
-    public ImmutableKieServerAmqScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir, String artifactDirs) {
-        withSourceLocation(gitRepoUrl, gitReference, gitContextDir);
+    public ImmutableKieServerAmqScenarioBuilder withSourceLocation(String gitReference, String gitContextDir, String artifactDirs) {
+        withSourceLocation(gitReference, gitContextDir);
 
         for (Server server : kieApp.getSpec().getObjects().getServers()) {
             server.getBuild().setArtifactDir(artifactDirs);

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.api.scenario.builder.WorkbenchKieServerPersistentScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.openshift.constants.ImageEnvVariables;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -38,11 +39,12 @@ import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.WorkbenchKieServerPersistentScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 
 public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<WorkbenchKieServerPersistentScenario> implements WorkbenchKieServerPersistentScenarioBuilder {
 
     private KieApp kieApp = new KieApp();
-    private boolean deploySSO = false;
+    private final ScenarioRequest request = new ScenarioRequest();
 
     public WorkbenchKieServerPersistentScenarioBuilderImpl() {
         List<Env> authenticationEnvVars = new ArrayList<>();
@@ -76,7 +78,7 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
 
     @Override
     public WorkbenchKieServerPersistentScenario getDeploymentScenarioInstance() {
-        return new WorkbenchKieServerPersistentScenarioImpl(kieApp, deploySSO);
+        return new WorkbenchKieServerPersistentScenarioImpl(kieApp, request);
     }
 
     @Override
@@ -87,7 +89,7 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
 
     @Override
     public WorkbenchKieServerPersistentScenarioBuilder deploySso() {
-        deploySSO = true;
+        request.enableDeploySso();
         SsoClient ssoClient = new SsoClient();
         ssoClient.setName("workbench-client");
         ssoClient.setSecret("workbench-secret");
@@ -100,6 +102,12 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
             ssoClient.setSecret("kie-server-" + i + "-secret");
             servers[i].setSsoClient(ssoClient);
         }
+        return this;
+    }
+
+    @Override
+    public WorkbenchKieServerPersistentScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.api.scenario.builder.WorkbenchKieServerScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.openshift.constants.ImageEnvVariables;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
@@ -34,11 +35,12 @@ import org.kie.cloud.openshift.operator.model.components.Env;
 import org.kie.cloud.openshift.operator.model.components.ImageRegistry;
 import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.scenario.WorkbenchKieServerScenarioImpl;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 
 public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<WorkbenchKieServerScenario> implements WorkbenchKieServerScenarioBuilder {
 
     private KieApp kieApp = new KieApp();
-    private boolean deployPrometheus = false;
+    private ScenarioRequest request = new ScenarioRequest();
 
     public WorkbenchKieServerScenarioBuilderImpl() {
         List<Env> authenticationEnvVars = new ArrayList<>();
@@ -71,7 +73,7 @@ public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
 
     @Override
     public WorkbenchKieServerScenario getDeploymentScenarioInstance() {
-        return new WorkbenchKieServerScenarioImpl(kieApp, deployPrometheus);
+        return new WorkbenchKieServerScenarioImpl(kieApp, request);
     }
 
     @Override
@@ -115,10 +117,16 @@ public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
 
     @Override
     public WorkbenchKieServerScenarioBuilder withPrometheusMonitoring() {
-        deployPrometheus = true;
+        request.enableDeployPrometheus();
         for (Server server : kieApp.getSpec().getObjects().getServers()) {
             server.addEnv(new Env(ImageEnvVariables.PROMETHEUS_SERVER_EXT_DISABLED, "false"));
         }
+        return this;
+    }
+
+    @Override
+    public WorkbenchKieServerScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl.java
@@ -23,6 +23,7 @@ import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.DeploymentScenarioListener;
 import org.kie.cloud.api.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario;
 import org.kie.cloud.api.scenario.builder.WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.openshift.constants.ImageEnvVariables;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -43,13 +44,14 @@ import org.kie.cloud.openshift.operator.model.components.SmartRouter;
 import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 import org.kie.cloud.openshift.template.ProjectProfile;
 
 public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario> implements
                                                                                           WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder {
 
     private KieApp kieApp = new KieApp();
-    private boolean deploySSO = false;
+    private ScenarioRequest request = new ScenarioRequest();
 
     public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl() {
         isScenarioAllowed();
@@ -89,7 +91,7 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBu
 
     @Override
     public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario getDeploymentScenarioInstance() {
-        return new WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl(kieApp, deploySSO);
+        return new WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl(kieApp, request);
     }
 
     @Override
@@ -100,7 +102,7 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBu
 
     @Override
     public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder deploySso() {
-        deploySSO = true;
+        request.enableDeploySso();
         SsoClient ssoClient = new SsoClient();
         ssoClient.setName("workbench-client");
         ssoClient.setSecret("workbench-secret");
@@ -113,6 +115,12 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBu
             ssoClient.setSecret("kie-server-" + i + "-secret");
             servers[i].setSsoClient(ssoClient);
         }
+        return this;
+    }
+
+    @Override
+    public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 
@@ -168,11 +176,16 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBu
     }
 
     @Override
-    public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir) {
+    public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withSourceLocation(String gitReference, String gitContextDir) {
+        if (request.getGitSettings() == null) {
+            throw new RuntimeException("Need to configure the git settings first");
+        }
+
         GitSource gitSource = new GitSource();
         gitSource.setContextDir(gitContextDir);
         gitSource.setReference(gitReference);
-        gitSource.setUri(gitRepoUrl);
+
+        request.getGitSettings().addOnRepositoryLoaded(gitSource::setUri);
 
         for (Server server : kieApp.getSpec().getObjects().getServers()) {
             if (server.getBuild() == null) {
@@ -185,8 +198,8 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBu
     }
 
     @Override
-    public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir, String artifactDirs) {
-        withSourceLocation(gitRepoUrl, gitReference, gitContextDir);
+    public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder withSourceLocation(String gitReference, String gitContextDir, String artifactDirs) {
+        withSourceLocation(gitReference, gitContextDir);
 
         for (Server server : kieApp.getSpec().getObjects().getServers()) {
             server.getBuild().setArtifactDir(artifactDirs);

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ImmutableKieServerAmqScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ImmutableKieServerAmqScenarioImpl.java
@@ -29,6 +29,7 @@ import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.ImmutableKieServerAmqScenario;
 import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
@@ -37,6 +38,7 @@ import org.kie.cloud.openshift.deployment.KieServerDeploymentImpl;
 import org.kie.cloud.openshift.template.OpenShiftTemplate;
 import org.kie.cloud.openshift.util.AmqImageStreamDeployer;
 import org.kie.cloud.openshift.util.AmqSecretDeployer;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.SsoDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,13 +49,15 @@ public class ImmutableKieServerAmqScenarioImpl extends KieCommonScenario<Immutab
     private SsoDeployment ssoDeployment;
     private AmqDeploymentImpl amqDeployment;
 
-    private boolean deploySso;
+    private GitProvider gitProvider;
+
+    private final ScenarioRequest request;
 
     private static final Logger logger = LoggerFactory.getLogger(KieServerWithExternalDatabaseScenario.class);
 
-    public ImmutableKieServerAmqScenarioImpl(Map<String, String> envVariables, boolean deploySso) {
+    public ImmutableKieServerAmqScenarioImpl(Map<String, String> envVariables, ScenarioRequest request) {
         super(envVariables);
-        this.deploySso = deploySso;
+        this.request = request;
     }
 
     @Override public KieServerDeployment getKieServerDeployment() {
@@ -62,7 +66,7 @@ public class ImmutableKieServerAmqScenarioImpl extends KieCommonScenario<Immutab
 
     @Override
     protected void deployKieDeployments() {
-        if (deploySso) {
+        if (request.isDeploySso()) {
             ssoDeployment = SsoDeployer.deploy(project);
 
             envVariables.put(OpenShiftTemplateConstants.SSO_URL, SsoDeployer.createSsoEnvVariable(ssoDeployment.getUrl().toString()));
@@ -70,6 +74,10 @@ public class ImmutableKieServerAmqScenarioImpl extends KieCommonScenario<Immutab
 
             envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_SSO_CLIENT, "kie-server-client");
             envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_SSO_SECRET, "kie-server-secret");
+        }
+
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
         }
 
         logger.info("Creating AMQ secret");
@@ -134,5 +142,10 @@ public class ImmutableKieServerAmqScenarioImpl extends KieCommonScenario<Immutab
     @Override
     public AmqDeployment getAmqDeployment() {
         return amqDeployment;
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ImmutableKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ImmutableKieServerScenarioImpl.java
@@ -28,11 +28,13 @@ import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.ImmutableKieServerScenario;
 import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.deployment.KieServerDeploymentImpl;
 import org.kie.cloud.openshift.template.OpenShiftTemplate;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.SsoDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,14 +43,15 @@ public class ImmutableKieServerScenarioImpl extends KieCommonScenario<ImmutableK
 
     private KieServerDeploymentImpl kieServerDeployment;
     private SsoDeployment ssoDeployment;
+    private GitProvider gitProvider;
 
-    private boolean deploySso;
+    private final ScenarioRequest request;
 
     private static final Logger logger = LoggerFactory.getLogger(KieServerWithExternalDatabaseScenario.class);
 
-    public ImmutableKieServerScenarioImpl(Map<String, String> envVariables, boolean deploySso) {
+    public ImmutableKieServerScenarioImpl(Map<String, String> envVariables, ScenarioRequest request) {
         super(envVariables);
-        this.deploySso = deploySso;
+        this.request = request;
     }
 
     @Override public KieServerDeployment getKieServerDeployment() {
@@ -57,7 +60,7 @@ public class ImmutableKieServerScenarioImpl extends KieCommonScenario<ImmutableK
 
     @Override
     protected void deployKieDeployments() {
-        if (deploySso) {
+        if (request.isDeploySso()) {
             ssoDeployment = SsoDeployer.deploy(project);
 
             envVariables.put(OpenShiftTemplateConstants.SSO_URL, SsoDeployer.createSsoEnvVariable(ssoDeployment.getUrl().toString()));
@@ -65,6 +68,10 @@ public class ImmutableKieServerScenarioImpl extends KieCommonScenario<ImmutableK
 
             envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_SSO_CLIENT, "kie-server-client");
             envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_SSO_SECRET, "kie-server-secret");
+        }
+
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
         }
 
         logger.info("Processing template and creating resources from {}", OpenShiftTemplate.KIE_SERVER_HTTPS_S2I.getTemplateUrl());
@@ -111,4 +118,9 @@ public class ImmutableKieServerScenarioImpl extends KieCommonScenario<ImmutableK
     public SsoDeployment getSsoDeployment() {
         return ssoDeployment;
 	}
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
+    }
 }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerPersistentScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerPersistentScenarioImpl.java
@@ -29,6 +29,7 @@ import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.SsoDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
@@ -38,6 +39,7 @@ import org.kie.cloud.openshift.deployment.KieServerDeploymentImpl;
 import org.kie.cloud.openshift.deployment.WorkbenchDeploymentImpl;
 import org.kie.cloud.openshift.template.OpenShiftTemplate;
 import org.kie.cloud.openshift.template.ProjectProfile;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.SsoDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,20 +49,21 @@ public class WorkbenchKieServerPersistentScenarioImpl extends KieCommonScenario<
     private WorkbenchDeploymentImpl workbenchDeployment;
     private KieServerDeploymentImpl kieServerDeployment;
     private SsoDeployment ssoDeployment;
+    private GitProvider gitProvider;
 
     private final ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();
-    private boolean deploySso;
+    private final ScenarioRequest request;
 
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchKieServerPersistentScenarioImpl.class);
 
-    public WorkbenchKieServerPersistentScenarioImpl(Map<String, String> envVariables, boolean deploySso) {
+    public WorkbenchKieServerPersistentScenarioImpl(Map<String, String> envVariables, ScenarioRequest request) {
         super(envVariables);
-        this.deploySso = deploySso;
+        this.request = request;
     }
 
     @Override
     protected void deployKieDeployments() {
-        if (deploySso) {
+        if (request.isDeploySso()) {
             ssoDeployment = SsoDeployer.deploy(project);
 
             envVariables.put(OpenShiftTemplateConstants.SSO_URL, SsoDeployer.createSsoEnvVariable(ssoDeployment.getUrl().toString()));
@@ -72,6 +75,10 @@ public class WorkbenchKieServerPersistentScenarioImpl extends KieCommonScenario<
 
             envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_SSO_CLIENT, "kie-server-client");
             envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_SSO_SECRET, "kie-server-secret");
+        }
+
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
         }
 
         logger.info("Processing template and creating resources from " + OpenShiftTemplate.WORKBENCH_KIE_SERVER_PERSISTENT.getTemplateUrl().toString());
@@ -146,5 +153,10 @@ public class WorkbenchKieServerPersistentScenarioImpl extends KieCommonScenario<
     @Override
     public SsoDeployment getSsoDeployment() {
         return ssoDeployment;
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/WorkbenchKieServerScenarioImpl.java
@@ -30,12 +30,14 @@ import org.kie.cloud.api.deployment.PrometheusDeployment;
 import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.deployment.KieServerDeploymentImpl;
 import org.kie.cloud.openshift.deployment.WorkbenchDeploymentImpl;
 import org.kie.cloud.openshift.template.OpenShiftTemplate;
+import org.kie.cloud.openshift.util.Git;
 import org.kie.cloud.openshift.util.PrometheusDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,14 +46,15 @@ public class WorkbenchKieServerScenarioImpl extends KieCommonScenario<WorkbenchK
 
     private WorkbenchDeploymentImpl workbenchDeployment;
     private KieServerDeploymentImpl kieServerDeployment;
-    private boolean deployPrometheus;
+    private final ScenarioRequest request;
     private PrometheusDeployment prometheusDeployment;
+    private GitProvider gitProvider;
 
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchKieServerScenarioImpl.class);
 
-    public WorkbenchKieServerScenarioImpl(Map<String, String> envVariables, boolean deployPrometheus) {
+    public WorkbenchKieServerScenarioImpl(Map<String, String> envVariables, ScenarioRequest request) {
         super(envVariables);
-        this.deployPrometheus = deployPrometheus;
+        this.request = request;
     }
 
     @Override
@@ -68,8 +71,12 @@ public class WorkbenchKieServerScenarioImpl extends KieCommonScenario<WorkbenchK
         kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
         kieServerDeployment.setPassword(envVariables.get(OpenShiftTemplateConstants.DEFAULT_PASSWORD));
 
-        if (deployPrometheus) {
+        if (request.isDeployPrometheus()) {
             prometheusDeployment = PrometheusDeployer.deploy(project, kieServerDeployment);
+        }
+
+        if (request.getGitSettings() != null) {
+            gitProvider = Git.createProvider(project, request.getGitSettings());
         }
 
         logger.info("Waiting for Workbench deployment to become ready.");
@@ -132,5 +139,10 @@ public class WorkbenchKieServerScenarioImpl extends KieCommonScenario<WorkbenchK
     @Override
     public Optional<PrometheusDeployment> getPrometheusDeployment() {
         return Optional.ofNullable(prometheusDeployment);
+    }
+
+    @Override
+    public GitProvider getGitProvider() {
+        return gitProvider;
     }
 }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
@@ -21,18 +21,20 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
 import org.kie.cloud.api.scenario.builder.ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.constants.ProjectSpecificPropertyNames;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
 import org.kie.cloud.openshift.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 
 public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderTemplates<ClusteredWorkbenchKieServerDatabasePersistentScenario> implements
                                                                               ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder {
 
     private final Map<String, String> envVariables = new HashMap<>();
-    private boolean deploySso = false;
+    private final ScenarioRequest request = new ScenarioRequest();
     private final ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();
 
     public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl() {
@@ -46,7 +48,7 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
 
     @Override
     protected ClusteredWorkbenchKieServerDatabasePersistentScenario getDeploymentScenarioInstance() {
-        return new ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl(envVariables, deploySso);
+        return new ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl(envVariables, request);
     }
 
     @Override
@@ -63,9 +65,15 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
 
     @Override
     public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder deploySso() {
-        deploySso = true;
+        request.enableDeploySso();
         envVariables.put(OpenShiftTemplateConstants.SSO_USERNAME, DeploymentConstants.getSsoServiceUser());
         envVariables.put(OpenShiftTemplateConstants.SSO_PASSWORD, DeploymentConstants.getSsoServicePassword());
+        return this;
+    }
+
+    @Override
+    public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ImmutableKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/ImmutableKieServerScenarioBuilderImpl.java
@@ -21,16 +21,18 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.ImmutableKieServerScenario;
 import org.kie.cloud.api.scenario.builder.ImmutableKieServerScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
 import org.kie.cloud.openshift.scenario.ImmutableKieServerScenarioImpl;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 
 public class ImmutableKieServerScenarioBuilderImpl extends KieScenarioBuilderImpl<ImmutableKieServerScenarioBuilder, ImmutableKieServerScenario> implements ImmutableKieServerScenarioBuilder {
 
     private final Map<String, String> envVariables = new HashMap<>();
-    private boolean deploySso = false;
+    private ScenarioRequest request = new ScenarioRequest();
 
     public ImmutableKieServerScenarioBuilderImpl() {
         envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
@@ -42,7 +44,7 @@ public class ImmutableKieServerScenarioBuilderImpl extends KieScenarioBuilderImp
 
     @Override
     protected ImmutableKieServerScenario getDeploymentScenarioInstance() {
-        return new ImmutableKieServerScenarioImpl(envVariables, deploySso);
+        return new ImmutableKieServerScenarioImpl(envVariables, request);
     }
 
     @Override
@@ -64,27 +66,36 @@ public class ImmutableKieServerScenarioBuilderImpl extends KieScenarioBuilderImp
     }
 
     @Override
-    public ImmutableKieServerScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir) {
-        envVariables.put(OpenShiftTemplateConstants.SOURCE_REPOSITORY_URL, gitRepoUrl);
+    public ImmutableKieServerScenarioBuilder withSourceLocation(String gitReference, String gitContextDir) {
         envVariables.put(OpenShiftTemplateConstants.SOURCE_REPOSITORY_REF, gitReference);
         envVariables.put(OpenShiftTemplateConstants.CONTEXT_DIR, gitContextDir);
+
+        if (request.getGitSettings() == null) {
+            throw new RuntimeException("Need to configure the git settings first");
+        }
+
+        request.getGitSettings().addOnRepositoryLoaded(gitRepoUrl -> envVariables.put(OpenShiftTemplateConstants.SOURCE_REPOSITORY_URL, gitRepoUrl));
         return this;
     }
 
     @Override
-    public ImmutableKieServerScenarioBuilder withSourceLocation(String gitRepoUrl, String gitReference, String gitContextDir, String artifactDirs) {
-        envVariables.put(OpenShiftTemplateConstants.SOURCE_REPOSITORY_URL, gitRepoUrl);
-        envVariables.put(OpenShiftTemplateConstants.SOURCE_REPOSITORY_REF, gitReference);
-        envVariables.put(OpenShiftTemplateConstants.CONTEXT_DIR, gitContextDir);
+    public ImmutableKieServerScenarioBuilder withSourceLocation(String gitReference, String gitContextDir, String artifactDirs) {
+        withSourceLocation(gitReference, gitContextDir);
         envVariables.put(OpenShiftTemplateConstants.ARTIFACT_DIR, artifactDirs);
         return this;
     }
 
     @Override
     public ImmutableKieServerScenarioBuilder deploySso() {
-        deploySso = true;
+        request.enableDeploySso();
         envVariables.put(OpenShiftTemplateConstants.SSO_USERNAME, DeploymentConstants.getSsoServiceUser());
         envVariables.put(OpenShiftTemplateConstants.SSO_PASSWORD, DeploymentConstants.getSsoServicePassword());
+        return this;
+    }
+
+    @Override
+    public ImmutableKieServerScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
@@ -21,18 +21,20 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.api.scenario.builder.WorkbenchKieServerPersistentScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.constants.ProjectSpecificPropertyNames;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 import org.kie.cloud.openshift.scenario.WorkbenchKieServerPersistentScenarioImpl;
 
 public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderTemplates<WorkbenchKieServerPersistentScenario> implements WorkbenchKieServerPersistentScenarioBuilder {
 
     private final Map<String, String> envVariables = new HashMap<>();
     private final ProjectSpecificPropertyNames propertyNames = ProjectSpecificPropertyNames.create();
-    private boolean deploySSO = false;
+    private final ScenarioRequest request = new ScenarioRequest();
 
     public WorkbenchKieServerPersistentScenarioBuilderImpl() {
         envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
@@ -42,7 +44,7 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
 
     @Override
     public WorkbenchKieServerPersistentScenario getDeploymentScenarioInstance() {
-        return new WorkbenchKieServerPersistentScenarioImpl(envVariables, deploySSO);
+        return new WorkbenchKieServerPersistentScenarioImpl(envVariables, request);
     }
 
     @Override
@@ -59,9 +61,15 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
 
     @Override
     public WorkbenchKieServerPersistentScenarioBuilder deploySso() {
-        deploySSO = true;
+        request.enableDeploySso();
         envVariables.put(OpenShiftTemplateConstants.SSO_USERNAME, DeploymentConstants.getSsoServiceUser());
         envVariables.put(OpenShiftTemplateConstants.SSO_PASSWORD, DeploymentConstants.getSsoServicePassword());
+        return this;
+    }
+
+    @Override
+    public WorkbenchKieServerPersistentScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
@@ -24,14 +24,16 @@ import java.util.stream.Stream;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.api.scenario.builder.WorkbenchKieServerScenarioBuilder;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
+import org.kie.cloud.openshift.scenario.ScenarioRequest;
 import org.kie.cloud.openshift.scenario.WorkbenchKieServerScenarioImpl;
 
 public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderTemplates<WorkbenchKieServerScenario> implements WorkbenchKieServerScenarioBuilder {
 
     private final Map<String, String> envVariables = new HashMap<>();
-    private boolean deployPrometheus = false;
+    private ScenarioRequest request = new ScenarioRequest();
 
     public WorkbenchKieServerScenarioBuilderImpl() {
         envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
@@ -41,7 +43,7 @@ public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
 
     @Override
     public WorkbenchKieServerScenario getDeploymentScenarioInstance() {
-        return new WorkbenchKieServerScenarioImpl(envVariables, deployPrometheus);
+        return new WorkbenchKieServerScenarioImpl(envVariables, request);
     }
 
     @Override
@@ -91,8 +93,14 @@ public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
 
     @Override
     public WorkbenchKieServerScenarioBuilder withPrometheusMonitoring() {
-        deployPrometheus = true;
+        request.enableDeployPrometheus();
         envVariables.put(OpenShiftTemplateConstants.PROMETHEUS_SERVER_EXT_DISABLED, "false");
+        return this;
+    }
+
+    @Override
+    public WorkbenchKieServerScenarioBuilder withGitSettings(GitSettings gitSettings) {
+        request.setGitSettings(gitSettings);
         return this;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/GogsDeploymentImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/GogsDeploymentImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.deployment;
+
+import java.net.URL;
+
+import org.kie.cloud.api.deployment.GogsDeployment;
+import org.kie.cloud.openshift.resource.Project;
+
+public class GogsDeploymentImpl extends OpenShiftDeployment implements GogsDeployment {
+
+    private static final String USERNAME = "root";
+    private static final String PASSWORD = "redhat";
+
+    private String serviceName;
+    private URL url;
+
+    public GogsDeploymentImpl(Project project) {
+        super(project);
+    }
+
+    @Override
+    public String getServiceName() {
+        if (serviceName == null) {
+            serviceName = ServiceUtil.getGogsServiceName(getOpenShift());
+        }
+
+        return serviceName;
+    }
+
+    @Override
+    public String getUrl() {
+        if (url == null) {
+            url = getHttpRouteUrl(getServiceName()).orElseThrow(() -> new RuntimeException("No Gogs URL is available."));
+        }
+
+        return url.toString();
+    }
+
+    @Override
+    public String getUsername() {
+        return USERNAME;
+    }
+
+    @Override
+    public String getPassword() {
+        return PASSWORD;
+    }
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/ServiceUtil.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/ServiceUtil.java
@@ -38,6 +38,7 @@ public class ServiceUtil {
     private static final Pattern DOCKER_REGEXP = Pattern.compile("registry");
     private static final Pattern MAVEN_NEXUS_REPOSITORY_REGEXP = Pattern.compile("nexus");
     private static final Pattern LDAP_REGEXP = Pattern.compile(".*ldap.*");
+    private static final Pattern GOGS_REGEXP = Pattern.compile(".*gogs.*");
     private static final Pattern PROMETHEUS_REGEXP = Pattern.compile("prometheus-operated");
 
     public static String getControllerServiceName(OpenShift openShift) {
@@ -82,6 +83,10 @@ public class ServiceUtil {
 
     public static String getDockerServiceName(OpenShift openShift) {
         return getServiceName(openShift, DOCKER_REGEXP);
+    }
+
+    public static String getGogsServiceName(OpenShift openShift) {
+        return getServiceName(openShift, GOGS_REGEXP);
     }
 
     public static String getMavenNexusServiceName(OpenShift openShift) {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/CloudProperties.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/CloudProperties.java
@@ -32,6 +32,7 @@ public final class CloudProperties {
 
     private static final String CLOUD_PROPERTIES_LOCATION = "cloud.properties.location";
     private static final String LDAP_DOCKER_IMAGE_PROPERTY = "ldap.docker.image";
+    private static final String GOGS_DOCKER_IMAGE_PROPERTY = "gogs.docker.image";
 
     private static CloudProperties INSTANCE;
 
@@ -49,6 +50,10 @@ public final class CloudProperties {
 
     public String getLdapDockerImage() {
         return getProperty(LDAP_DOCKER_IMAGE_PROPERTY);
+    }
+
+    public String getGogsDockerImage() {
+        return getProperty(GOGS_DOCKER_IMAGE_PROPERTY);
     }
 
     private String getProperty(String key) {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/ScenarioRequest.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/scenario/ScenarioRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.scenario;
+
+import org.kie.cloud.api.settings.GitSettings;
+
+public class ScenarioRequest {
+
+    private boolean deploySso = false;
+    private GitSettings gitSettings;
+    private boolean deployPrometheus = false;
+
+    public boolean isDeploySso() {
+        return deploySso;
+    }
+
+    public GitSettings getGitSettings() {
+        return gitSettings;
+    }
+
+    public boolean isDeployPrometheus() {
+        return deployPrometheus;
+    }
+
+    public ScenarioRequest enableDeploySso() {
+        this.deploySso = true;
+        return this;
+    }
+
+    public ScenarioRequest setGitSettings(GitSettings gitSettings) {
+        this.gitSettings = gitSettings;
+        return this;
+    }
+
+    public ScenarioRequest enableDeployPrometheus() {
+        this.deployPrometheus = true;
+        return this;
+    }
+
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/Git.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/Git.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.util;
+
+import java.util.ServiceLoader;
+
+import org.kie.cloud.api.git.GitProvider;
+import org.kie.cloud.api.git.GitProviderFactory;
+import org.kie.cloud.api.settings.GitSettings;
+import org.kie.cloud.openshift.resource.Project;
+
+/**
+ * Utility to create a GitProvider instance and configure the GIT repository in a standard approach.
+ *
+ * Once the GitProvider is created, it will raise a repository loaded event (using the Observer pattern), so external configuration
+ * can be updated transparently.
+ *
+ */
+public class Git {
+
+    public static synchronized GitProvider createProvider(Project project, GitSettings settings) {
+        ServiceLoader<GitProviderFactory> factories = ServiceLoader.load(GitProviderFactory.class);
+        for (GitProviderFactory factory : factories) {
+            if (factory.providerType().equals(settings.getProvider())) {
+                initFactory(factory, project);
+
+                GitProvider provider = createProvider(settings, factory);
+
+                onRepositoryLoaded(provider, settings);
+                return provider;
+            }
+        }
+
+        throw new RuntimeException("GIT provider not found");
+    }
+
+    private static GitProvider createProvider(GitSettings settings, GitProviderFactory factory) {
+        GitProvider provider = factory.createGitProvider();
+
+        provider.createGitRepository(settings.getRepositoryName(), settings.getRepositoryPath());
+        return provider;
+    }
+
+    private static void initFactory(GitProviderFactory factory, Project project) {
+        factory.initGitConfigurationProperties();
+
+        if (factory instanceof ProjectInitializer) {
+            ((ProjectInitializer) factory).load(project);
+        }
+    }
+
+    private static void onRepositoryLoaded(GitProvider provider, GitSettings settings) {
+        if (settings.getRepositoryLoadedActions() != null) {
+            String repoUrl = provider.getRepositoryUrl(settings.getRepositoryName());
+            settings.getRepositoryLoadedActions().forEach(action -> action.accept(repoUrl));
+        }
+    }
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/ProjectInitializer.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/ProjectInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,15 +11,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+<<<<<<< HEAD:framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/scenario/EmployeeRosteringScenario.java
 */
+package org.kie.cloud.openshift.util;
 
-package org.kie.cloud.git;
+import org.kie.cloud.openshift.resource.Project;
 
-public interface GitProvider {
-
-    String createGitRepositoryWithPrefix(String repositoryPrefixName, String repositoryPath);
-
-    void deleteGitRepository(String repositoryName);
-
-    String getRepositoryUrl(String repositoryName);
+/**
+ * Interface to state the implementations need the Openshift project instance to work.
+ */
+public interface ProjectInitializer {
+    void load(Project project);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
       </dependency>
       <dependency>
         <groupId>org.kie</groupId>
+        <artifactId>ha-core-infra</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
         <artifactId>openshift-kie-hacep</artifactId>
         <version>${version.org.kie}</version>
       </dependency>

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -107,9 +107,7 @@
     <module>test-cloud-remote</module>
     <module>test-cloud-optaweb</module>
     <module>test-cloud-performance</module>
-    <!-- Temporarily disable ha-cep module due to ongoing massive refactoring DROOLS-5083
     <module>test-cloud-ha-cep</module>
-    -->
   </modules>
 
   <build>

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -390,6 +390,14 @@ $ keytool -import -trustcacerts -alias name -keypass pass -storepass pass -keyst
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>keytool-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractCloudIntegrationTest.java
+++ b/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/AbstractCloudIntegrationTest.java
@@ -15,6 +15,8 @@
 
 package org.kie.cloud.tests.common;
 
+import java.util.UUID;
+
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 
@@ -52,4 +54,8 @@ public abstract class AbstractCloudIntegrationTest {
     protected static final String PROJECT_SOURCE_FOLDER = "/kjars-sources";
 
     protected static final DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactoryLoader.getInstance();
+
+    protected static String generateNameWithPrefix(String prefix) {
+        return prefix + "-" + UUID.randomUUID().toString().substring(0, 4);
+    }
 }

--- a/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/client/util/WorkbenchUtils.java
+++ b/test-cloud/test-cloud-common/src/main/java/org/kie/cloud/tests/common/client/util/WorkbenchUtils.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import org.guvnor.rest.client.CloneProjectRequest;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
+import org.kie.cloud.api.git.GitProvider;
+import org.kie.cloud.api.scenario.KieDeploymentScenario;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
 import org.kie.cloud.tests.common.time.TimeUtils;
 import org.kie.server.api.model.KieContainerStatus;
@@ -39,6 +41,13 @@ public class WorkbenchUtils {
 
     private static final Duration WAIT_STEP = Duration.ofSeconds(1);
     private static final Duration MAX_WAIT_DURATION = Duration.ofSeconds(15);
+
+    public static void deployProjectToWorkbench(String repositoryName, KieDeploymentScenario<?> deploymentScenario, String projectName) {
+        GitProvider gitProvider = deploymentScenario.getGitProvider();
+        WorkbenchDeployment workbenchDeployment = deploymentScenario.getWorkbenchDeployments().get(0);
+
+        deployProjectToWorkbench(gitProvider.getRepositoryUrl(repositoryName), workbenchDeployment, projectName);
+    }
 
     public static void deployProjectToWorkbench(String repositoryUrl, WorkbenchDeployment workbenchDeployment, String projectName) {
         CloneProjectRequest cloneProjectRequest = createCloneProjectRequest(repositoryUrl, projectName);

--- a/test-cloud/test-cloud-ha-cep/pom.xml
+++ b/test-cloud/test-cloud-ha-cep/pom.xml
@@ -26,11 +26,11 @@
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>openshift-kie-hacep</artifactId>
+      <artifactId>sample-hacep-project-kjar</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>sample-hacep-project-kjar</artifactId>
+      <artifactId>ha-core-infra</artifactId>
     </dependency>
 
     <dependency>

--- a/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPFailoverIntegrationTest.java
+++ b/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPFailoverIntegrationTest.java
@@ -28,11 +28,15 @@ import org.kie.cloud.api.scenario.HACepScenario;
 import org.kie.cloud.openshift.resource.Project;
 import org.kie.cloud.openshift.resource.impl.ProjectImpl;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.hacep.core.InfraFactory;
 import org.kie.hacep.sample.kjar.StockTickEvent;
 import org.kie.remote.CommonConfig;
 import org.kie.remote.RemoteFactHandle;
 import org.kie.remote.RemoteKieSession;
 import org.kie.remote.TopicsConfig;
+import org.kie.remote.impl.RemoteKieSessionImpl;
+import org.kie.remote.impl.producer.Producer;
+import org.kie.remote.util.KafkaRemoteUtil;
 
 public class HACEPFailoverIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<HACepScenario> {
 
@@ -45,11 +49,12 @@ public class HACEPFailoverIntegrationTest extends AbstractMethodIsolatedCloudInt
     public void testLeaderFailoverFactCountTest() throws Exception {
         final TopicsConfig topicsConfig = TopicsConfig.getDefaultTopicsConfig();
         final Properties connectionProperties = deploymentScenario.getKafkaConnectionProperties();
-        connectionProperties.putAll(CommonConfig.getStatic());
+        connectionProperties.putAll(HACEPTestsUtils.getProperties());
 
         final int numberOfFacts = 10;
 
-        try (RemoteKieSession producer = RemoteKieSession.create(connectionProperties, topicsConfig);
+        final Producer prod = InfraFactory.getProducer(false);
+        try (RemoteKieSession producer = new RemoteKieSessionImpl(connectionProperties, topicsConfig, KafkaRemoteUtil.getListener(connectionProperties, false), prod);
             Project project = new ProjectImpl(deploymentScenario.getNamespace())) {
 
             for (int i = 0; i < numberOfFacts; i++) {
@@ -79,9 +84,10 @@ public class HACEPFailoverIntegrationTest extends AbstractMethodIsolatedCloudInt
     public void testRulesAreEvaluatedByReplicas() throws Exception {
         final TopicsConfig topicsConfig = TopicsConfig.getDefaultTopicsConfig();
         final Properties connectionProperties = deploymentScenario.getKafkaConnectionProperties();
-        connectionProperties.putAll(CommonConfig.getStatic());
+        connectionProperties.putAll(HACEPTestsUtils.getProperties());
 
-        try (RemoteKieSession producer = RemoteKieSession.create(connectionProperties, topicsConfig);
+        final Producer prod = InfraFactory.getProducer(false);
+        try (RemoteKieSession producer = new RemoteKieSessionImpl(connectionProperties, topicsConfig, KafkaRemoteUtil.getListener(connectionProperties, false), prod);
              Project project = new ProjectImpl(deploymentScenario.getNamespace())) {
 
             StockTickEvent stockTickEvent = new StockTickEvent("RHT",
@@ -108,9 +114,10 @@ public class HACEPFailoverIntegrationTest extends AbstractMethodIsolatedCloudInt
     public void testScaleToZeroAndBack() throws Exception {
         final TopicsConfig topicsConfig = TopicsConfig.getDefaultTopicsConfig();
         final Properties connectionProperties = deploymentScenario.getKafkaConnectionProperties();
-        connectionProperties.putAll(CommonConfig.getStatic());
+        connectionProperties.putAll(HACEPTestsUtils.getProperties());
 
-        try (RemoteKieSession producer = RemoteKieSession.create(connectionProperties, topicsConfig);
+        final Producer prod = InfraFactory.getProducer(false);
+        try (RemoteKieSession producer = new RemoteKieSessionImpl(connectionProperties, topicsConfig, KafkaRemoteUtil.getListener(connectionProperties, false), prod);
              Project project = new ProjectImpl(deploymentScenario.getNamespace())) {
 
             StockTickEvent stockTickEvent = new StockTickEvent("RHT",

--- a/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPRuleEngineIntegrationTest.java
+++ b/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPRuleEngineIntegrationTest.java
@@ -25,11 +25,14 @@ import org.junit.Test;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.scenario.HACepScenario;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.hacep.core.InfraFactory;
 import org.kie.hacep.sample.kjar.StockTickEvent;
-import org.kie.remote.CommonConfig;
 import org.kie.remote.RemoteFactHandle;
 import org.kie.remote.RemoteKieSession;
 import org.kie.remote.TopicsConfig;
+import org.kie.remote.impl.RemoteKieSessionImpl;
+import org.kie.remote.impl.producer.Producer;
+import org.kie.remote.util.KafkaRemoteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +49,10 @@ public class HACEPRuleEngineIntegrationTest extends AbstractMethodIsolatedCloudI
     public void testInsertRetrieveFact() throws Exception {
         final TopicsConfig topicsConfig = TopicsConfig.getDefaultTopicsConfig();
         final Properties connectionProperties = deploymentScenario.getKafkaConnectionProperties();
-        connectionProperties.putAll(CommonConfig.getStatic());
+        connectionProperties.putAll(HACEPTestsUtils.getProperties());
 
-        try (RemoteKieSession producer = RemoteKieSession.create(connectionProperties, topicsConfig)) {
+        final Producer prod = InfraFactory.getProducer(false);
+        try (RemoteKieSession producer = new RemoteKieSessionImpl(connectionProperties, topicsConfig, KafkaRemoteUtil.getListener(connectionProperties, false), prod)) {
             final StockTickEvent fact = new StockTickEvent("RHT",
                                                              ThreadLocalRandom.current().nextLong(80,
                                                                                                   100));
@@ -64,10 +68,11 @@ public class HACEPRuleEngineIntegrationTest extends AbstractMethodIsolatedCloudI
     public void testInsertMultipleFacts() throws Exception {
         final TopicsConfig topicsConfig = TopicsConfig.getDefaultTopicsConfig();
         final Properties connectionProperties = deploymentScenario.getKafkaConnectionProperties();
-        connectionProperties.putAll(CommonConfig.getStatic());
+        connectionProperties.putAll(HACEPTestsUtils.getProperties());
         final int numberOfFacts = 100;
 
-        try (RemoteKieSession producer = RemoteKieSession.create(connectionProperties, topicsConfig)) {
+        final Producer prod = InfraFactory.getProducer(false);
+        try (RemoteKieSession producer = new RemoteKieSessionImpl(connectionProperties, topicsConfig, KafkaRemoteUtil.getListener(connectionProperties, false), prod)) {
             for (int i = 0; i < numberOfFacts; i++) {
                 StockTickEvent stockTickEvent = new StockTickEvent("RHT",
                                                            ThreadLocalRandom.current().nextLong(80,
@@ -86,8 +91,10 @@ public class HACEPRuleEngineIntegrationTest extends AbstractMethodIsolatedCloudI
     public void testFireRules() throws Exception {
         final TopicsConfig topicsConfig = TopicsConfig.getDefaultTopicsConfig();
         final Properties connectionProperties = deploymentScenario.getKafkaConnectionProperties();
-        connectionProperties.putAll(CommonConfig.getStatic());
-        try (RemoteKieSession producer = RemoteKieSession.create(connectionProperties, topicsConfig)) {
+        connectionProperties.putAll(HACEPTestsUtils.getProperties());
+
+        final Producer prod = InfraFactory.getProducer(false);
+        try (RemoteKieSession producer = new RemoteKieSessionImpl(connectionProperties, topicsConfig, KafkaRemoteUtil.getListener(connectionProperties, false), prod)) {
             StockTickEvent stockTickEvent = new StockTickEvent("RHT",
                                                                ThreadLocalRandom.current().nextLong(80,
                                                                                                     100));

--- a/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPStreamingAPIIntegrationTest.java
+++ b/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPStreamingAPIIntegrationTest.java
@@ -25,10 +25,16 @@ import org.junit.Test;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.scenario.HACepScenario;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
+import org.kie.hacep.core.InfraFactory;
 import org.kie.hacep.sample.kjar.StockTickEvent;
 import org.kie.remote.CommonConfig;
+import org.kie.remote.RemoteKieSession;
 import org.kie.remote.RemoteStreamingKieSession;
 import org.kie.remote.TopicsConfig;
+import org.kie.remote.impl.RemoteKieSessionImpl;
+import org.kie.remote.impl.RemoteStreamingKieSessionImpl;
+import org.kie.remote.impl.producer.Producer;
+import org.kie.remote.util.KafkaRemoteUtil;
 
 public class HACEPStreamingAPIIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<HACepScenario> {
 
@@ -41,9 +47,10 @@ public class HACEPStreamingAPIIntegrationTest extends AbstractMethodIsolatedClou
     public void testStreamingAPI() throws Exception {
         final TopicsConfig topicsConfig = TopicsConfig.getDefaultTopicsConfig();
         final Properties connectionProperties = deploymentScenario.getKafkaConnectionProperties();
-        connectionProperties.putAll(CommonConfig.getStatic());
+        connectionProperties.putAll(HACEPTestsUtils.getProperties());
 
-        try (RemoteStreamingKieSession producer = RemoteStreamingKieSession.create(connectionProperties, topicsConfig)) {
+        final Producer prod = InfraFactory.getProducer(false);
+        try (RemoteStreamingKieSession producer = new RemoteStreamingKieSessionImpl(connectionProperties, topicsConfig, KafkaRemoteUtil.getListener(connectionProperties, false), prod)) {
             StockTickEvent stockTickEvent = new StockTickEvent("RHT",
                                                                ThreadLocalRandom.current().nextLong(80,
                                                                                                         100));

--- a/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPTestsUtils.java
+++ b/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPTestsUtils.java
@@ -19,6 +19,11 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Pod;
 import org.assertj.core.api.Assertions;
 import org.kie.cloud.openshift.resource.Project;
+import org.kie.remote.CommonConfig;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 
 public class HACEPTestsUtils {
 
@@ -37,5 +42,17 @@ public class HACEPTestsUtils {
         Assertions.assertThat(pod).isNotNull();
 
         return pod;
+    }
+
+    public static Properties getProperties() {
+        Properties props = CommonConfig.getStatic();
+
+        try (InputStream is = HACEPTestsUtils.class.getClassLoader().getResourceAsStream("consumer.properties")) {
+            props.load(is);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to find configuration properties", e);
+        }
+
+        return props;
     }
 }

--- a/test-cloud/test-cloud-performance/pom.xml
+++ b/test-cloud/test-cloud-performance/pom.xml
@@ -35,7 +35,6 @@
     <dependency>
       <groupId>org.kie.cloud</groupId>
       <artifactId>framework-cloud-api</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.cloud</groupId>

--- a/test-cloud/test-cloud-performance/pom.xml
+++ b/test-cloud/test-cloud-performance/pom.xml
@@ -153,15 +153,5 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>keytool-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
   </build>
 </project>

--- a/test-cloud/test-cloud-performance/src/main/java/org/kie/cloud/provider/git/Git.java
+++ b/test-cloud/test-cloud-performance/src/main/java/org/kie/cloud/provider/git/Git.java
@@ -15,7 +15,7 @@
 
 package org.kie.cloud.provider.git;
 
-import org.kie.cloud.git.GitProvider;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.git.GitProviderService;
 
 public class Git {

--- a/test-cloud/test-cloud-performance/src/test/java/org/kie/cloud/integrationtests/s2i/BaseJbpmEJBTimersPerfIntegrationTest.java
+++ b/test-cloud/test-cloud-performance/src/test/java/org/kie/cloud/integrationtests/s2i/BaseJbpmEJBTimersPerfIntegrationTest.java
@@ -60,39 +60,38 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.jbpm.process.instance.ProcessInstance.STATE_ACTIVE;
-import static org.jbpm.process.instance.ProcessInstance.STATE_COMPLETED;
+import static org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE;
+import static org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED;
 
 @RunWith(Parameterized.class)
 public abstract class BaseJbpmEJBTimersPerfIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario> {
+
+    private static final String REPOSITORY_NAME = generateNameWithPrefix("KieServerS2iJbpmRepository");
 
     protected static final String MEMORY = "memory";
     protected static final String CPU = "cpu";
     protected static final List<Integer> ACTIVE_STATUS = Collections.singletonList(STATE_ACTIVE);
     protected static final List<Integer> COMPLETED_STATUS = Collections.singletonList(STATE_COMPLETED);
-    
+
     protected static final Logger logger = LoggerFactory.getLogger(BaseJbpmEJBTimersPerfIntegrationTest.class);
 
     protected static final int PROCESSES_COUNT = Integer.parseInt(System.getProperty("processesCount", "5000"));
-    
-    
     protected static final double PERF_INDEX = Double.parseDouble(System.getProperty("perfIndex", "3.0"));
-    
     protected static final String HEAP = System.getProperty("heap","4Gi");
     protected static final int SCALE_COUNT = Integer.parseInt(System.getProperty("scale", "1"));
     protected static final int REPETITIONS = Integer.parseInt(System.getProperty("repetitions", "1"));
-    protected static final int REFRESH_INTERVAL = Integer.parseInt(System.getProperty("refreshInterval", "30"));   
-    protected static final int ROUTER_TIMEOUT = Integer.parseInt(System.getProperty("routerTimeout", "60"));   
-    protected static final String ROUTER_BALANCE = System.getProperty("routerBalance", "roundrobin");   
-    
+    protected static final int REFRESH_INTERVAL = Integer.parseInt(System.getProperty("refreshInterval", "30"));
+    protected static final int ROUTER_TIMEOUT = Integer.parseInt(System.getProperty("routerTimeout", "60"));
+    protected static final String ROUTER_BALANCE = System.getProperty("routerBalance", "roundrobin");
+
     protected static final String ONE_TIMER_DURATION_PROCESS_ID = "timers-testing.OneTimerDate";
-    
+
     protected static final String KIE_CONTAINER_DEPLOYMENT = CONTAINER_ID + "=" + Kjar.DEFINITION.toString();
 
     protected static final String REPO_BRANCH = "master";
     protected static final String PROJECT_SOURCE_FOLDER = "/kjars-sources";
     protected static final int MINIMUM_OFFSET = 45;
-    
+
     @Parameter(value = 0)
     public String testScenarioName;
 
@@ -120,17 +119,17 @@ public abstract class BaseJbpmEJBTimersPerfIntegrationTest extends AbstractMetho
 
         return scenarios;
     }
-    
+
     protected KieServicesClient kieServicesClient;
     protected ProcessServicesClient processServicesClient;
     protected UserTaskServicesClient taskServicesClient;
-    
+
     protected QueryServicesClient queryServicesClient;
 
-    private static String gitRepositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iJbpmRepository", BaseJbpmEJBTimersPerfIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
-    
+    private static String gitRepositoryName = Git.getProvider().createGitRepository(REPOSITORY_NAME, BaseJbpmEJBTimersPerfIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+
     protected List<String> pods = new ArrayList<String>();
-        
+
     protected Map<String, Integer> completedHostNameDistribution;
 
     @Override
@@ -159,14 +158,14 @@ public abstract class BaseJbpmEJBTimersPerfIntegrationTest extends AbstractMetho
         } else {
             throw new RuntimeException("wrong scale parameter, should be equal or greater than 1");
         }
-        
+
         deploymentScenario.getKieServerDeployment().setRouterTimeout(Duration.ofMinutes(ROUTER_TIMEOUT));
         deploymentScenario.getKieServerDeployment().setRouterBalance(ROUTER_BALANCE);
-        
+
         kieServicesClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment(), Duration.ofMinutes(60).toMillis());
-        
+
         logger.info("Setting timeout for kieServerClient to {}", Duration.ofMinutes(60).toMillis());
-        
+
         processServicesClient = KieServerClientProvider.getProcessClient(deploymentScenario.getKieServerDeployment());
         queryServicesClient = KieServerClientProvider.getQueryClient(deploymentScenario.getKieServerDeployment());
     }
@@ -200,17 +199,17 @@ public abstract class BaseJbpmEJBTimersPerfIntegrationTest extends AbstractMetho
         logger.info("============================= STARTING SCENARIO =============================");
         runSingleScenario();
         logger.info("============================= SCENARIO COMPLETE =============================");
-    
+
         logger.info("============================= GATHERING STATISTICS =============================");
         gatherAndAssertStatistics();
         writeCSV();
-        logger.info("============================= STATISTICS GATHERED =============================");       
+        logger.info("============================= STATISTICS GATHERED =============================");
     }
 
     protected abstract void writeCSV() throws IOException;
 
     protected abstract void runSingleScenario();
-       
+
     protected void startAndWaitForStartingThreads(int numberOfThreads, Duration duration, Integer iterations, Runnable runnable) {
        List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < numberOfThreads; i++) {
@@ -226,9 +225,9 @@ public abstract class BaseJbpmEJBTimersPerfIntegrationTest extends AbstractMetho
                 throw new RuntimeException(e);
             }
         });
-        
+
     }
-    
+
     protected Runnable getStartingRunnable(String containerId, String processId, Map<String, Object> parameters) {
         return () -> {
             try {
@@ -240,12 +239,12 @@ public abstract class BaseJbpmEJBTimersPerfIntegrationTest extends AbstractMetho
             }
         };
     }
-    
+
     protected void waitForAllProcessesToComplete(Duration waitForCompletionDuration) {
         BooleanSupplier completionCondition = () -> queryServicesClient.findProcessInstancesByStatus(ACTIVE_STATUS, 0, 1).isEmpty();
         TimeUtils.wait(waitForCompletionDuration, Duration.of(1, ChronoUnit.SECONDS), completionCondition);
     }
-    
+
     private void gatherAndAssertStatistics() {
         int numberOfPages = 1 + (PROCESSES_COUNT / 5000);// including one additional page to check there are no more processes
 
@@ -257,36 +256,36 @@ public abstract class BaseJbpmEJBTimersPerfIntegrationTest extends AbstractMetho
         }
 
         logger.info("Completed processes count: {}", completedProcesses.size());
-        
+
         List<ProcessInstance> activeProcesses = queryServicesClient.findProcessInstancesByStatus(Collections.singletonList(org.jbpm.process.instance.ProcessInstance.STATE_ACTIVE), 0, 100);
         logger.info("Active processes count: {}", activeProcesses.size());
-        
+
         assertThat(activeProcesses).isEmpty();
-        
+
         assertThat(completedProcesses).hasSize(PROCESSES_COUNT);
-       
+
         Map<String, Integer> startedHostNameDistribution = new HashMap<>();
         completedHostNameDistribution = new HashMap<>();
-       
+
         for (String pod : pods) {
             completedHostNameDistribution.put(pod, 0);
             startedHostNameDistribution.put(pod, 0);
         }
-        
+
         for (int i = 0; i < numberOfPages; i++) {
           for (String pod : pods) {
            int sizeCompleted = queryServicesClient.findProcessInstancesByVariableAndValue("hostName", pod, COMPLETED_STATUS, i, 5000).size();
            completedHostNameDistribution.put(pod, completedHostNameDistribution.get(pod) + sizeCompleted);
-           
+
            int sizeStarted = queryOldValue(i, pod);
            startedHostNameDistribution.put(pod, startedHostNameDistribution.get(pod) + sizeStarted);
           }
         }
-        
+
         logger.info("Processes were completed with this distribution: {}", completedHostNameDistribution);
-        logger.info("Processes were started with this distribution: {}", startedHostNameDistribution);       
+        logger.info("Processes were started with this distribution: {}", startedHostNameDistribution);
     }
-    
+
     private void scaleKieServerTo(int count) {
         deploymentScenario.getKieServerDeployment().scale(count);
         deploymentScenario.getKieServerDeployment().waitForScale();
@@ -295,13 +294,13 @@ public abstract class BaseJbpmEJBTimersPerfIntegrationTest extends AbstractMetho
             pods.add(i.getName());
         }
     }
-    
-    private int queryOldValue(int page, String oldValue) {  
+
+    private int queryOldValue(int page, String oldValue) {
         QueryFilterSpec spec = new QueryFilterSpecBuilder()
                 .equalsTo("variableId", "hostName")
                 .equalsTo("oldValue", oldValue)
                 .get();
-          
+
         return queryServicesClient.query("jbpmOldValueVarSearch", QueryServicesClient.QUERY_MAP_PI_WITH_VARS, spec, page, 5000, ProcessInstance.class).size();
     }
 

--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -24,11 +24,14 @@
     <dependency>
       <groupId>org.kie.cloud</groupId>
       <artifactId>framework-cloud-api</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.cloud</groupId>
       <artifactId>framework-openshift</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.cloud</groupId>
+      <artifactId>framework-git</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.cloud</groupId>
@@ -38,10 +41,6 @@
       <groupId>org.kie.cloud</groupId>
       <artifactId>framework-cloud-common</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.kie.cloud</groupId>
-      <artifactId>framework-git</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.cloud</groupId>

--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -162,15 +162,5 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>keytool-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
   </build>
 </project>

--- a/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/git/GitUtils.java
+++ b/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/git/GitUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.git;
+
+import org.kie.cloud.api.scenario.KieDeploymentScenario;
+
+/**
+ * Utility class with methods to work with the GIT provider (provided in the deployment scenario). *
+ */
+public final class GitUtils {
+
+    private GitUtils() {
+
+    }
+
+    /**
+     * Delete the specified repository name using the git provider in the deploymentScenario.
+     *
+     * @param repositoryName repository to delete
+     * @param deploymentScenario git provider to use
+     */
+    public static final void deleteGitRepository(String repositoryName, KieDeploymentScenario<?> deploymentScenario) {
+        deploymentScenario.getGitProvider().deleteGitRepository(repositoryName);
+    }
+}

--- a/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/git/GogsOpenshiftProviderFactory.java
+++ b/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/git/GogsOpenshiftProviderFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.git;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+
+import org.kie.cloud.api.deployment.GogsDeployment;
+import org.kie.cloud.api.git.GitProvider;
+import org.kie.cloud.api.git.GitProviderFactory;
+import org.kie.cloud.git.gogs.GogsGitProvider;
+import org.kie.cloud.openshift.deployment.GogsDeploymentImpl;
+import org.kie.cloud.openshift.resource.CloudProperties;
+import org.kie.cloud.openshift.resource.Project;
+import org.kie.cloud.openshift.util.ProjectInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * GIT provider factory to deploy a GOGS instance into Openshift.
+ */
+public class GogsOpenshiftProviderFactory implements GitProviderFactory, ProjectInitializer {
+
+    private static final String GOGS = "Gogs";
+    private static final String GOGS_TEMPLATE = "/deployments/gogs.yaml";
+
+    private static final Logger logger = LoggerFactory.getLogger(GogsOpenshiftProviderFactory.class);
+
+    private Project project;
+
+    @Override
+    public void load(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public String providerType() {
+        return GOGS;
+    }
+
+    @Override
+    public GitProvider createGitProvider() {
+        if (project == null) {
+            throw new RuntimeException("Project not initialized. Call load() before creating GIT provider");
+        }
+
+        GogsDeployment deployment = deploy(project);
+        return new GogsGitProvider(deployment.getUrl(), deployment.getUsername(), deployment.getPassword());
+    }
+
+    private static GogsDeployment deploy(Project project) {
+        logger.info("Creating internal GOGS instance.");
+        project.runOcCommandAsAdmin("adm", "policy", "add-scc-to-user", "anyuid", "-z", "default");
+        project.processTemplateAndCreateResources(getGogsTemplate(), getGogsProperties(project));
+        project.runOcCommandAsAdmin("expose", "service", "gogs");
+
+        logger.info("Waiting for Gogs deployment to become ready.");
+        GogsDeployment deployment = new GogsDeploymentImpl(project);
+        deployment.waitForScale();
+
+        return deployment;
+    }
+
+    private static Map<String, String> getGogsProperties(Project project) {
+        return Collections.singletonMap("GOGS_DOCKER_IMAGE", CloudProperties.getInstance().getGogsDockerImage());
+    }
+
+    private static URL getGogsTemplate() {
+        try {
+            return new URL("file://" + GogsOpenshiftProviderFactory.class.getResource(GOGS_TEMPLATE).getFile());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Wrong GOGS template location", e);
+        }
+    }
+}

--- a/test-cloud/test-cloud-remote/src/main/resources/META-INF/services/org.kie.cloud.api.git.GitProviderFactory
+++ b/test-cloud/test-cloud-remote/src/main/resources/META-INF/services/org.kie.cloud.api.git.GitProviderFactory
@@ -1,0 +1,1 @@
+org.kie.cloud.git.GogsOpenshiftProviderFactory

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
@@ -64,8 +64,8 @@ public class ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest ex
         } catch (UnsupportedOperationException ex) {
             Assume.assumeFalse(ex.getMessage().startsWith("Not supported"));
         }
-        deploymentScenario.setLogFolderName(
-                                            ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.class.getSimpleName());
+
+        deploymentScenario.setLogFolderName(ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest.class.getSimpleName());
         ScenarioDeployer.deployScenario(deploymentScenario);
 
         // Setup test providers
@@ -105,6 +105,7 @@ public class ClusteredWorkbenchKieServerPersistentScenarioLdapIntegrationTest ex
     @Test
     public void testDeployContainerFromWorkbench() {
         fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(),
-                                                                  deploymentScenario.getKieServerDeployment());
+                                                                  deploymentScenario.getKieServerDeployment(),
+                                                                  deploymentScenario.getGitProvider());
     }
 }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
@@ -150,7 +150,8 @@ public class WorkbenchKieServerPersistentScenarioLdapIntegrationTest extends Abs
     @Test
     public void testDeployContainerFromWorkbench() {
         fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(),
-                                                                  deploymentScenario.getKieServerDeployment());
+                                                                  deploymentScenario.getKieServerDeployment(),
+                                                                  deploymentScenario.getGitProvider());
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/s2i/KieServerS2iWithLdapDroolsIntegrationTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,11 +38,12 @@ import org.kie.api.runtime.ExecutionResults;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.scenario.KieDeploymentScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.api.settings.LdapSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.git.GitUtils;
 import org.kie.cloud.integrationtests.category.ApbNotSupported;
 import org.kie.cloud.maven.MavenDeployer;
-import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.client.util.LdapSettingsConstants;
@@ -60,6 +61,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Parameterized.class)
 @Category(ApbNotSupported.class) // Because DroolsServerFilterClasses not supported yet
 public class KieServerS2iWithLdapDroolsIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario<?>> {
+
+    private static final String REPOSITORY_NAME = generateNameWithPrefix("KieServerS2iDroolsRepository");
 
     private static final Logger logger = LoggerFactory.getLogger(KieServerS2iWithLdapDroolsIntegrationTest.class);
 
@@ -86,10 +89,16 @@ public class KieServerS2iWithLdapDroolsIntegrationTest extends AbstractMethodIso
                                                              .withLdapRoleRecursion(LdapSettingsConstants.ROLE_RECURSION)
                                                              .withLdapDefaultRole(LdapSettingsConstants.DEFAULT_ROLE)
                                                              .build();
+
+        GitSettings gitSettings = GitSettings.fromProperties()
+                                             .withRepository(REPOSITORY_NAME,
+                                                             KieServerS2iWithLdapDroolsIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+
         try {
             KieDeploymentScenario<?> immutableKieServerWithDatabaseScenario = deploymentScenarioFactory.getWorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenarioBuilder()
                                                                                                        .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                                       .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
+                                                                                                       .withGitSettings(gitSettings)
+                                                                                                       .withSourceLocation(REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
                                                                                                        .withDroolsServerFilterClasses(false)
                                                                                                        .withInternalLdap(ldapSettings)
                                                                                                        .build();
@@ -101,7 +110,8 @@ public class KieServerS2iWithLdapDroolsIntegrationTest extends AbstractMethodIso
         try {
             KieDeploymentScenario<?> immutableKieServerScenario = deploymentScenarioFactory.getImmutableKieServerScenarioBuilder()
                                                                                            .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                           .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
+                                                                                           .withGitSettings(gitSettings)
+                                                                                           .withSourceLocation(REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
                                                                                            .withDroolsServerFilterClasses(false)
                                                                                            .withInternalLdap(ldapSettings)
                                                                                            .build();
@@ -131,7 +141,6 @@ public class KieServerS2iWithLdapDroolsIntegrationTest extends AbstractMethodIso
     private static final String REPO_BRANCH = "master";
     private static final String PROJECT_SOURCE_FOLDER = "/kjars-sources";
 
-    private static String gitRepositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", KieServerS2iWithLdapDroolsIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
     private ClassLoader kjarClassLoader;
     private KieCommands commandsFactory = KieServices.Factory.get().getCommands();
     private Set<Class<?>> extraClasses;
@@ -157,9 +166,9 @@ public class KieServerS2iWithLdapDroolsIntegrationTest extends AbstractMethodIso
         ruleClient = kieServicesClient.getServicesClient(RuleServicesClient.class);
     }
 
-    @AfterClass
-    public static void deleteRepo() {
-        Git.getProvider().deleteGitRepository(gitRepositoryName);
+    @After
+    public void deleteRepo() {
+        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
@@ -14,8 +14,6 @@
  */
 package org.kie.cloud.integrationtests.persistence;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -37,11 +35,12 @@ import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenario;
 import org.kie.cloud.api.scenario.KieDeploymentScenario;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
+import org.kie.cloud.git.GitUtils;
 import org.kie.cloud.integrationtests.category.OperatorNotSupported;
-import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.client.util.WorkbenchUtils;
@@ -58,10 +57,13 @@ import org.kie.wb.test.rest.client.WorkbenchClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @RunWith(Parameterized.class)
 @Category({OperatorNotSupported.class}) // Operator doesn't support scaling Workbench to 0 for this scenario
 public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario<?>> {
 
+    private static final String REPOSITORY_NAME = generateNameWithPrefix(WorkbenchPersistenceIntegrationTest.class.getSimpleName());
     private static final Logger logger = LoggerFactory.getLogger(WorkbenchPersistenceIntegrationTest.class);
 
     @Parameter(value = 0)
@@ -69,8 +71,6 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
 
     @Parameter(value = 1)
     public KieDeploymentScenario<?> workbenchKieServerScenario;
-
-    private String repositoryName;
 
     private WorkbenchClient workbenchClient;
     private KieServerControllerClient kieControllerClient;
@@ -83,9 +83,15 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
         List<Object[]> scenarios = new ArrayList<>();
         DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactoryLoader.getInstance();
 
+        GitSettings gitSettings = GitSettings.fromProperties()
+                                             .withRepository(REPOSITORY_NAME,
+                                                             WorkbenchPersistenceIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
+
         try {
             WorkbenchKieServerPersistentScenario workbenchKieServerPersistentScenario = deploymentScenarioFactory.getWorkbenchKieServerPersistentScenarioBuilder()
-                .build();
+                    .withGitSettings(gitSettings)
+                    .build();
+
             scenarios.add(new Object[] { "Workbench + KIE Server - Persistent", workbenchKieServerPersistentScenario });
         } catch (UnsupportedOperationException ex) {
             logger.info("Workbench + KIE Server - Persistent is skipped.", ex);
@@ -93,7 +99,8 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
 
         try {
             ClusteredWorkbenchKieServerDatabasePersistentScenario clusteredWorkbenchKieServerDatabasePersistentScenario = deploymentScenarioFactory.getClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder()
-                .build();
+                    .withGitSettings(gitSettings)
+                    .build();
                 scenarios.add(new Object[]{"Clustered Workbench + KIE Server + Database - Persistent", clusteredWorkbenchKieServerDatabasePersistentScenario});
         } catch (UnsupportedOperationException ex) {
             logger.info("Clustered Workbench + KIE Server + Database is skipped.", ex);
@@ -117,17 +124,12 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
 
     @After
     public void tearDown() {
-        if (repositoryName != null) {
-            Git.getProvider().deleteGitRepository(repositoryName);
-            repositoryName = null;
-        }
+        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
     }
 
     @Test
     public void testWorkbenchControllerPersistence() {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), WorkbenchPersistenceIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
-
-        WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), workbenchDeployment, DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(REPOSITORY_NAME, deploymentScenario, DEFINITION_PROJECT_NAME);
 
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
         WorkbenchUtils.saveContainerSpec(kieControllerClient, serverInfo.getServerId(), serverInfo.getName(), CONTAINER_ID, CONTAINER_ALIAS, Kjar.DEFINITION, KieContainerStatus.STARTED);

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/probe/ReadinessProbeIntegrationTest.java
@@ -44,12 +44,13 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.scenario.WorkbenchKieServerPersistentScenario;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.common.provider.WorkbenchClientProvider;
+import org.kie.cloud.git.GitUtils;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.integrationtests.category.OperatorNotSupported;
-import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.client.util.WorkbenchUtils;
@@ -70,13 +71,13 @@ import org.slf4j.LoggerFactory;
 @Category({Baseline.class, OperatorNotSupported.class}) // Operator doesn't support scaling Workbench to 0 for this scenario
 public class ReadinessProbeIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<WorkbenchKieServerScenario> {
 
+    private static final String REPOSITORY_NAME = generateNameWithPrefix(ReadinessProbeIntegrationTest.class.getSimpleName());
+
     @Parameter(value = 0)
     public String testScenarioName;
 
     @Parameter(value = 1)
     public WorkbenchKieServerScenario workbenchKieServerScenario;
-
-    String repositoryName;
 
     @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
@@ -86,6 +87,9 @@ public class ReadinessProbeIntegrationTest extends AbstractMethodIsolatedCloudIn
         try {
             WorkbenchKieServerScenario workbenchKieServerScenario = deploymentScenarioFactory.getWorkbenchKieServerScenarioBuilder()
                     .withInternalMavenRepo()
+                    .withGitSettings(GitSettings.fromProperties()
+                                     .withRepository(REPOSITORY_NAME,
+                                                     ReadinessProbeIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile()))
                     .build();
             scenarios.add(new Object[]{"Workbench + KIE Server", workbenchKieServerScenario});
         } catch (UnsupportedOperationException ex) {
@@ -129,10 +133,7 @@ public class ReadinessProbeIntegrationTest extends AbstractMethodIsolatedCloudIn
             httpKieServerClient.close();
         }
 
-        if (repositoryName != null) {
-            Git.getProvider().deleteGitRepository(repositoryName);
-            repositoryName = null;
-        }
+        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
     }
 
     @Test
@@ -162,9 +163,7 @@ public class ReadinessProbeIntegrationTest extends AbstractMethodIsolatedCloudIn
 
     @Test
     public void testKieServerReadinessProbe() {
-        String repositoryName = Git.getProvider().createGitRepositoryWithPrefix(deploymentScenario.getWorkbenchDeployment().getNamespace(), ReadinessProbeIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile());
-
-        WorkbenchUtils.deployProjectToWorkbench(Git.getProvider().getRepositoryUrl(repositoryName), deploymentScenario.getWorkbenchDeployment(), DEFINITION_PROJECT_NAME);
+        WorkbenchUtils.deployProjectToWorkbench(REPOSITORY_NAME, deploymentScenario, DEFINITION_PROJECT_NAME);
 
         KieServerInfo serverInfo = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment()).getServerInfo().getResult();
         KieServerControllerClient kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(deploymentScenario.getWorkbenchDeployment());

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iDroolsIntegrationTest.java
@@ -18,11 +18,10 @@ package org.kie.cloud.integrationtests.s2i;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,11 +38,12 @@ import org.kie.api.runtime.ExecutionResults;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.scenario.KieDeploymentScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.git.GitUtils;
 import org.kie.cloud.integrationtests.category.ApbNotSupported;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.maven.MavenDeployer;
-import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.server.api.model.KieContainerResource;
@@ -61,6 +61,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category({Baseline.class, ApbNotSupported.class}) // Because DroolsServerFilterClasses not supported yet
 public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario<?>> {
 
+    private static final String REPOSITORY_NAME = generateNameWithPrefix("KieServerS2iDroolsRepository");
+
     private static final Logger logger = LoggerFactory.getLogger(KieServerS2iDroolsIntegrationTest.class);
 
     @Parameter(value = 0)
@@ -74,10 +76,15 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
         List<Object[]> scenarios = new ArrayList<>();
         DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactoryLoader.getInstance();
 
+        GitSettings gitSettings = GitSettings.fromProperties()
+                                             .withRepository(REPOSITORY_NAME,
+                                                             KieServerS2iDroolsIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+
         try {
             KieDeploymentScenario<?> immutableKieServerWithDatabaseScenario = deploymentScenarioFactory.getWorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenarioBuilder()
                                                                                                        .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                                       .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
+                                                                                                       .withGitSettings(gitSettings)
+                                                                                                       .withSourceLocation(REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
                                                                                                        .withDroolsServerFilterClasses(false)
                                                                                                        .build();
             scenarios.add(new Object[] { "Immutable KIE Server Database S2I", immutableKieServerWithDatabaseScenario });
@@ -88,7 +95,8 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
         try {
             KieDeploymentScenario<?> immutableKieServerScenario = deploymentScenarioFactory.getImmutableKieServerScenarioBuilder()
                                                                                            .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                           .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
+                                                                                           .withGitSettings(gitSettings)
+                                                                                           .withSourceLocation(REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
                                                                                            .withDroolsServerFilterClasses(false)
                                                                                            .build();
             scenarios.add(new Object[] { "Immutable KIE Server S2I", immutableKieServerScenario });
@@ -115,7 +123,6 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
 
     private static final String REPO_BRANCH = "master";
     private static final String PROJECT_SOURCE_FOLDER = "/kjars-sources";
-    private static String gitRepositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", KieServerS2iDroolsIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
     private ClassLoader kjarClassLoader;
     private KieCommands commandsFactory = KieServices.Factory.get().getCommands();
@@ -140,9 +147,9 @@ public class KieServerS2iDroolsIntegrationTest extends AbstractMethodIsolatedClo
         ruleClient = kieServicesClient.getServicesClient(RuleServicesClient.class);
     }
 
-    @AfterClass
-    public static void deleteRepo() {
-        Git.getProvider().deleteGitRepository(gitRepositoryName);
+    @After
+    public void deleteRepo() {
+        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iJbpmIntegrationTest.java
@@ -21,12 +21,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario;
+import org.kie.cloud.api.settings.GitSettings;
+import org.kie.cloud.git.GitUtils;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.OperatorNotSupported;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
 import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
-import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.tests.common.client.util.Kjar;
@@ -34,8 +35,9 @@ import org.kie.cloud.tests.common.client.util.Kjar;
 @Category({JBPMOnly.class})
 public class KieServerS2iJbpmIntegrationTest extends AbstractCloudIntegrationTest {
 
+    private static final String REPOSITORY_NAME = generateNameWithPrefix("KieServerS2iJbpmRepository");
+
     private static WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario deploymentScenario;
-    private static String repositoryName;
     private static ProcessTestProvider processTestProvider;
     private static HttpsKieServerTestProvider httpsKieServerTestProvider;
     private static HttpsWorkbenchTestProvider httpsWorkbenchTestProvider;
@@ -48,12 +50,13 @@ public class KieServerS2iJbpmIntegrationTest extends AbstractCloudIntegrationTes
 
     @BeforeClass
     public static void initializeDeployment() {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iJbpmRepository", KieServerS2iJbpmIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
-
         try {
             deploymentScenario = deploymentScenarioFactory.getWorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenarioBuilder()
                     .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                    .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                    .withGitSettings(GitSettings.fromProperties()
+                                             .withRepository(REPOSITORY_NAME,
+                                                             KieServerS2iJbpmIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile()))
+                    .withSourceLocation(REPO_BRANCH, DEFINITION_PROJECT_NAME)
                     .build();
         } catch (UnsupportedOperationException ex) {
             Assume.assumeFalse(ex.getMessage().startsWith("Not supported"));
@@ -70,7 +73,7 @@ public class KieServerS2iJbpmIntegrationTest extends AbstractCloudIntegrationTes
 
     @AfterClass
     public static void cleanEnvironment() {
-        Git.getProvider().deleteGitRepository(repositoryName);
+        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
         ScenarioDeployer.undeployScenario(deploymentScenario);
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/KieServerS2iOptaplannerIntegrationTest.java
@@ -19,12 +19,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,9 +36,10 @@ import org.kie.api.runtime.KieContainer;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.scenario.KieDeploymentScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.git.GitUtils;
 import org.kie.cloud.maven.MavenDeployer;
-import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.server.api.model.ReleaseId;
@@ -53,6 +53,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario<?>> {
+
+    private static final String REPOSITORY_NAME = generateNameWithPrefix("KieServerS2iOptaplannerRepository");
 
     private static final Logger logger = LoggerFactory.getLogger(KieServerS2iOptaplannerIntegrationTest.class);
 
@@ -81,8 +83,6 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
     private static final String REPO_BRANCH = "master";
     private static final String PROJECT_SOURCE_FOLDER = "/kjars-sources";
 
-    private static String gitRepositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iOptaplannerRepository", KieServerS2iOptaplannerIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
-
     private KieContainer kieContainer;
     private SolverServicesClient solverClient;
 
@@ -91,10 +91,15 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
         List<Object[]> scenarios = new ArrayList<>();
         DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactoryLoader.getInstance();
 
+        GitSettings gitSettings = GitSettings.fromProperties()
+                                             .withRepository(REPOSITORY_NAME,
+                                                             KieServerS2iOptaplannerIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+
         try {
             KieDeploymentScenario<?> immutableKieServerWithDatabaseScenario = deploymentScenarioFactory.getWorkbenchRuntimeSmartRouterImmutableKieServerWithPostgreSqlScenarioBuilder()
                                                                                                        .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                                       .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
+                                                                                                       .withGitSettings(gitSettings)
+                                                                                                       .withSourceLocation(REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
                                                                                                        .build();
             scenarios.add(new Object[] { "Immutable KIE Server Database S2I", immutableKieServerWithDatabaseScenario });
         } catch (UnsupportedOperationException ex) {
@@ -104,7 +109,8 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
         try {
             KieDeploymentScenario<?> immutableKieServerScenario = deploymentScenarioFactory.getImmutableKieServerScenarioBuilder()
                                                                                            .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                           .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
+                                                                                           .withGitSettings(gitSettings)
+                                                                                           .withSourceLocation(REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
                                                                                            .build();
             scenarios.add(new Object[] { "Immutable KIE Server S2I", immutableKieServerScenario });
         } catch (UnsupportedOperationException ex) {
@@ -135,9 +141,9 @@ public class KieServerS2iOptaplannerIntegrationTest extends AbstractMethodIsolat
         solverClient = kieServerClient.getServicesClient(SolverServicesClient.class);
     }
 
-    @AfterClass
-    public static void deleteRepo() {
-        Git.getProvider().deleteGitRepository(gitRepositoryName);
+    @After
+    public void deleteRepo() {
+        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqDroolsIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqDroolsIntegrationTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,11 +39,12 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.deployment.AmqDeployment;
 import org.kie.cloud.api.scenario.KieDeploymentScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.git.GitUtils;
 import org.kie.cloud.integrationtests.category.Baseline;
 import org.kie.cloud.integrationtests.s2i.KieServerS2iDroolsIntegrationTest;
 import org.kie.cloud.maven.MavenDeployer;
-import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.server.api.model.KieContainerResource;
@@ -61,6 +62,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category({Baseline.class})
 public class KieServerS2iAmqDroolsIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario<?>> {
 
+    private static final String REPOSITORY_NAME = generateNameWithPrefix("KieServerS2iDroolsRepository");
+
     private static final Logger logger = LoggerFactory.getLogger(KieServerS2iAmqDroolsIntegrationTest.class);
 
     @Parameter(value = 0)
@@ -74,10 +77,15 @@ public class KieServerS2iAmqDroolsIntegrationTest extends AbstractMethodIsolated
         List<Object[]> scenarios = new ArrayList<>();
         DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactoryLoader.getInstance();
 
+        GitSettings gitSettings = GitSettings.fromProperties()
+                                             .withRepository(REPOSITORY_NAME,
+                                                             KieServerS2iDroolsIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+
         try {
             KieDeploymentScenario<?> immutableKieServerWithDatabaseScenario = deploymentScenarioFactory.getWorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioBuilder()
                                                                                                        .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                                       .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
+                                                                                                       .withGitSettings(gitSettings)
+                                                                                                       .withSourceLocation(REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
                                                                                                        .withDroolsServerFilterClasses(false)
                                                                                                        .build();
             scenarios.add(new Object[] { "Immutable KIE Server AMQ Database S2I", immutableKieServerWithDatabaseScenario });
@@ -88,7 +96,8 @@ public class KieServerS2iAmqDroolsIntegrationTest extends AbstractMethodIsolated
         try {
             KieDeploymentScenario<?> immutableKieServerScenario = deploymentScenarioFactory.getImmutableKieServerAmqScenarioBuilder()
                                                                                            .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                           .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
+                                                                                           .withGitSettings(gitSettings)
+                                                                                           .withSourceLocation(REPO_BRANCH, DEPLOYED_KJAR.getArtifactName())
                                                                                            .withDroolsServerFilterClasses(false)
                                                                                            .build();
             scenarios.add(new Object[] { "Immutable KIE Server AMQ S2I", immutableKieServerScenario });
@@ -115,7 +124,6 @@ public class KieServerS2iAmqDroolsIntegrationTest extends AbstractMethodIsolated
 
     private static final String REPO_BRANCH = "master";
     private static final String PROJECT_SOURCE_FOLDER = "/kjars-sources";
-    private static String gitRepositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iDroolsRepository", KieServerS2iDroolsIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
     private ClassLoader kjarClassLoader;
     private KieCommands commandsFactory = KieServices.Factory.get().getCommands();
@@ -146,9 +154,9 @@ public class KieServerS2iAmqDroolsIntegrationTest extends AbstractMethodIsolated
         ruleClient = KieServerClientProvider.getRuleJmsClient(kieServicesClient);
     }
 
-    @AfterClass
-    public static void deleteRepo() {
-        Git.getProvider().deleteGitRepository(gitRepositoryName);
+    @After
+    public void deleteRepo() {
+        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqHierarchicalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqHierarchicalIntegrationTest.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,10 +32,11 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.deployment.AmqDeployment;
 import org.kie.cloud.api.scenario.KieDeploymentScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.git.GitUtils;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.s2i.KieServerS2iHierarchicalIntegrationTest;
-import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.time.Constants;
@@ -54,6 +55,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Parameterized.class)
 public class KieServerS2iAmqHierarchicalIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario<?>> {
 
+    private static final String REPOSITORY_NAME = generateNameWithPrefix("KieServerS2iHierarchicalRepository");
+
     private static final Logger logger = LoggerFactory.getLogger(KieServerS2iAmqHierarchicalIntegrationTest.class);
 
     @Parameter(value = 0)
@@ -67,10 +70,15 @@ public class KieServerS2iAmqHierarchicalIntegrationTest extends AbstractMethodIs
         List<Object[]> scenarios = new ArrayList<>();
         DeploymentScenarioBuilderFactory deploymentScenarioFactory = DeploymentScenarioBuilderFactoryLoader.getInstance();
 
+        GitSettings gitSettings = GitSettings.fromProperties()
+                                             .withRepository(REPOSITORY_NAME,
+                                                             KieServerS2iHierarchicalIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
+
         try {
             KieDeploymentScenario<?> immutableKieServerWithDatabaseScenario = deploymentScenarioFactory.getWorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioBuilder()
                                                                                                        .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                                       .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, GIT_CONTEXT_DIR, BUILT_KJAR_FOLDER)
+                                                                                                       .withGitSettings(gitSettings)
+                                                                                                       .withSourceLocation(REPO_BRANCH, GIT_CONTEXT_DIR, BUILT_KJAR_FOLDER)
                                                                                                        .build();
             scenarios.add(new Object[] { "Immutable KIE Server AMQ Database S2I", immutableKieServerWithDatabaseScenario });
         } catch (UnsupportedOperationException ex) {
@@ -80,7 +88,8 @@ public class KieServerS2iAmqHierarchicalIntegrationTest extends AbstractMethodIs
         try {
             KieDeploymentScenario<?> immutableKieServerScenario = deploymentScenarioFactory.getImmutableKieServerAmqScenarioBuilder()
                                                                                            .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                                                                                           .withSourceLocation(Git.getProvider().getRepositoryUrl(gitRepositoryName), REPO_BRANCH, GIT_CONTEXT_DIR, BUILT_KJAR_FOLDER)
+                                                                                           .withGitSettings(gitSettings)
+                                                                                           .withSourceLocation(REPO_BRANCH, GIT_CONTEXT_DIR, BUILT_KJAR_FOLDER)
                                                                                            .build();
             scenarios.add(new Object[]{"Immutable KIE Server AMQ S2I", immutableKieServerScenario});
         } catch (UnsupportedOperationException ex) {
@@ -96,14 +105,10 @@ public class KieServerS2iAmqHierarchicalIntegrationTest extends AbstractMethodIs
 
     private static final String KIE_CONTAINER_DEPLOYMENT = CONTAINER_ID + "=" + Kjar.USERTASK.toString();
 
-    private static final String GIT_REPOSITORY_PREFIX = "KieServerS2iHierarchicalRepository";
-
     private static final String REPO_BRANCH = "master";
     private static final String PROJECT_SOURCE_FOLDER = "/kjars-sources";
     private static final String GIT_CONTEXT_DIR = "multimodule-project";
     private static final String BUILT_KJAR_FOLDER = "usertask-project/target,signaltask-project/target";
-
-    private static String gitRepositoryName = Git.getProvider().createGitRepositoryWithPrefix(GIT_REPOSITORY_PREFIX, KieServerS2iHierarchicalIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
 
     @Override
     protected KieDeploymentScenario<?> createDeploymentScenario(DeploymentScenarioBuilderFactory deploymentScenarioFactory) {
@@ -123,9 +128,9 @@ public class KieServerS2iAmqHierarchicalIntegrationTest extends AbstractMethodIs
         taskServicesClient = KieServerClientProvider.getTaskJmsClient(kieServicesClient);
     }
 
-    @AfterClass
-    public static void deleteRepo() {
-        Git.getProvider().deleteGitRepository(gitRepositoryName);
+    @After
+    public void deleteRepo() {
+        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqJbpmIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/s2i/jms/KieServerS2iAmqJbpmIntegrationTest.java
@@ -24,13 +24,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenario;
+import org.kie.cloud.api.settings.GitSettings;
 import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.git.GitUtils;
 import org.kie.cloud.integrationtests.category.ApbNotSupported;
 import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.s2i.KieServerS2iJbpmIntegrationTest;
 import org.kie.cloud.integrationtests.testproviders.HttpsKieServerTestProvider;
 import org.kie.cloud.integrationtests.testproviders.HttpsWorkbenchTestProvider;
-import org.kie.cloud.provider.git.Git;
 import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.tests.common.client.util.Kjar;
@@ -48,8 +49,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category({JBPMOnly.class})
 public class KieServerS2iAmqJbpmIntegrationTest extends AbstractCloudIntegrationTest {
 
+    private static final String REPOSITORY_NAME = generateNameWithPrefix("KieServerS2iAmqJbpmRepository");
+
     private static WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenario deploymentScenario;
-    private static String repositoryName;
 
     private static HttpsKieServerTestProvider httpsKieServerTestProvider;
     private static HttpsWorkbenchTestProvider httpsWorkbenchTestProvider;
@@ -65,12 +67,13 @@ public class KieServerS2iAmqJbpmIntegrationTest extends AbstractCloudIntegration
 
     @BeforeClass
     public static void initializeDeployment() {
-        repositoryName = Git.getProvider().createGitRepositoryWithPrefix("KieServerS2iAmqJbpmRepository", KieServerS2iJbpmIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile());
-
         try {
             deploymentScenario = deploymentScenarioFactory.getWorkbenchRuntimeSmartRouterImmutableKieServerAmqWithPostgreSqlScenarioBuilder()
                     .withContainerDeployment(KIE_CONTAINER_DEPLOYMENT)
-                    .withSourceLocation(Git.getProvider().getRepositoryUrl(repositoryName), REPO_BRANCH, DEFINITION_PROJECT_NAME)
+                    .withGitSettings(GitSettings.fromProperties()
+                                     .withRepository(REPOSITORY_NAME,
+                                                     KieServerS2iJbpmIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER).getFile()))
+                    .withSourceLocation(REPO_BRANCH, DEFINITION_PROJECT_NAME)
                     .build();
         } catch (UnsupportedOperationException ex) {
             Assume.assumeFalse(ex.getMessage().startsWith("Not supported"));
@@ -86,7 +89,7 @@ public class KieServerS2iAmqJbpmIntegrationTest extends AbstractCloudIntegration
 
     @AfterClass
     public static void cleanEnvironment() {
-        Git.getProvider().deleteGitRepository(repositoryName);
+        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
         ScenarioDeployer.undeployScenario(deploymentScenario);
     }
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTest.java
@@ -115,7 +115,7 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioIntegrationTes
 
     @Test
     public void testDeployContainerFromWorkbench() {
-        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment());
+        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment(), deploymentScenario.getGitProvider());
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest.java
@@ -114,7 +114,7 @@ public class ClusteredWorkbenchKieServerPersistentScenarioIntegrationTest extend
 
     @Test
     public void testDeployContainerFromWorkbench() {
-        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment());
+        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment(), deploymentScenario.getGitProvider());
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerPersistentScenarioIntegrationTest.java
@@ -110,7 +110,7 @@ public class WorkbenchKieServerPersistentScenarioIntegrationTest extends Abstrac
 
     @Test
     public void testDeployContainerFromWorkbench() {
-        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment());
+        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment(), deploymentScenario.getGitProvider());
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/WorkbenchKieServerScenarioIntegrationTest.java
@@ -103,6 +103,6 @@ public class WorkbenchKieServerScenarioIntegrationTest extends AbstractCloudInte
 
     @Test
     public void testDeployContainerFromWorkbench() {
-        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment());
+        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment(), deploymentScenario.getGitProvider());
     }
 }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
@@ -112,6 +112,6 @@ public class ClusteredWorkbenchKieServerPersistentScenarioSsoIntegrationTest ext
 
     @Test
     public void testDeployContainerFromWorkbench() {
-        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment());
+        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment(), deploymentScenario.getGitProvider());
     }
 }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/WorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/WorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
@@ -101,7 +101,7 @@ public class WorkbenchKieServerPersistentScenarioSsoIntegrationTest extends Abst
 
     @Test
     public void testDeployContainerFromWorkbench() {
-        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment());
+        fireRulesTestProvider.testDeployFromWorkbenchAndFireRules(deploymentScenario.getWorkbenchDeployment(), deploymentScenario.getKieServerDeployment(), deploymentScenario.getGitProvider());
     }
 
     @Test

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/FireRulesTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/FireRulesTestProvider.java
@@ -19,6 +19,7 @@ package org.kie.cloud.integrationtests.testproviders;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
@@ -28,11 +29,10 @@ import org.kie.api.runtime.ExecutionResults;
 import org.kie.cloud.api.deployment.KieServerDeployment;
 import org.kie.cloud.api.deployment.KjarDeployer;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
+import org.kie.cloud.api.git.GitProvider;
 import org.kie.cloud.api.scenario.DeploymentScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
-import org.kie.cloud.git.GitProvider;
-import org.kie.cloud.git.GitProviderService;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.client.util.WorkbenchUtils;
 import org.kie.server.api.model.KieContainerResource;
@@ -61,7 +61,7 @@ public class FireRulesTestProvider {
 
     /**
      * Create provider instance
-     * 
+     *
      * @return provider instance
      */
     public static FireRulesTestProvider create() {
@@ -70,9 +70,9 @@ public class FireRulesTestProvider {
 
     /**
      * Create provider instance and init it with given environment
-     * 
+     *
      * @param environment if not null, initialize this provider with the environment
-     * 
+     *
      * @return provider instance
      */
     public static FireRulesTestProvider create(DeploymentScenario<?> deploymentScenario) {
@@ -105,15 +105,16 @@ public class FireRulesTestProvider {
         }
     }
 
-    public void testDeployFromWorkbenchAndFireRules(WorkbenchDeployment workbenchDeployment, KieServerDeployment kieServerDeployment) {
+    public void testDeployFromWorkbenchAndFireRules(WorkbenchDeployment workbenchDeployment, KieServerDeployment kieServerDeployment, GitProvider gitProvider) {
         String containerId = "testDeployFromWorkbenchAndFireRules";
         String containerAlias = "alias-testDeployFromWorkbenchAndFireRules";
-        GitProvider gitProvider = new GitProviderService().createGitProvider();
         KieServerControllerClient kieControllerClient = KieServerControllerClientProvider.getKieServerControllerClient(workbenchDeployment);
         KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(kieServerDeployment);
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
 
-        String repositoryName = gitProvider.createGitRepositoryWithPrefix(workbenchDeployment.getNamespace(), FireRulesTestProvider.class.getResource("/kjars-sources/hello-rules").getFile());
+        String repositoryName = generateNameWithPrefix(workbenchDeployment.getNamespace());
+
+        gitProvider.createGitRepository(repositoryName, FireRulesTestProvider.class.getResource("/kjars-sources/hello-rules").getFile());
         try {
             WorkbenchUtils.deployProjectToWorkbench(gitProvider.getRepositoryUrl(repositoryName), workbenchDeployment, Kjar.HELLO_RULES.getArtifactName());
 
@@ -148,5 +149,9 @@ public class FireRulesTestProvider {
         assertThat(outcome).hasSize(2);
         assertThat(outcome.get(0)).startsWith(HELLO_RULE);
         assertThat(outcome.get(1)).startsWith(WORLD_RULE);
+    }
+
+    private static String generateNameWithPrefix(String prefix) {
+        return prefix + "-" + UUID.randomUUID().toString().substring(0, 4);
     }
 }

--- a/test-cloud/test-cloud-remote/src/test/resources/deployments/gogs.yaml
+++ b/test-cloud/test-cloud-remote/src/test/resources/deployments/gogs.yaml
@@ -1,0 +1,82 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: gogs
+  annotations:
+    name: gogs
+    description: Application template for gogs server
+message: A new gogs server was created
+
+parameters:
+- name: GOGS_DOCKER_IMAGE
+  displayName: GOGS Docker Image
+  description: The GOGS Docker Image URL
+  required: true
+objects:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: "rhba-qe-gogs"
+    annotations:
+      openshift.io/image.insecureRepository: 'true'
+  spec:
+    tags:
+    - name: 'latest'
+      from:
+        kind: DockerImage
+        name: ${GOGS_DOCKER_IMAGE}
+      importPolicy:
+        insecure: true
+      referencePolicy:
+        type: Local
+- kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    name: "gogs"
+    labels:
+      application: "gogs"
+  spec:
+    strategy:
+      type: Recreate
+    triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+        - "gogs"
+        from:
+          kind: ImageStreamTag
+          name: "rhba-qe-gogs:latest"
+    - type: ConfigChange
+    replicas: 1
+    selector:
+      deploymentConfig: "gogs"
+    template:
+      metadata:
+        name: "gogs"
+        labels:
+          application: "gogs"
+          deploymentConfig: "gogs"
+      spec:
+        containers:
+        - name: "gogs"
+          image: "rhba-qe-gogs:latest"
+          imagePullPolicy: Always
+          ports:
+          - name: "http"
+            containerPort: 3000
+            protocol: TCP
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: "gogs"
+    labels:
+      application: "gogs"
+  spec:
+    ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+    selector:
+      deploymentConfig: "gogs"


### PR DESCRIPTION
The idea was to create a dedicated GOGS instance as GIT Provider that lives in the same namespace as the running project test. This way we don't depend on third services to ensure the tests. 

Some problems I got during the development of this task were:
- Tests were using the GIT provider in a different test lifecycle (sometimes before the project even existed)
- We still want the ability to use the external GOGS instance

To manage the above challenges, I had to refactor all the tests to use this GIT instance the same way. Also, I followed the same approach as the LDAP deployment. Mainly, the tests will:

1. First create a TEST repository name. (a random string only). Example:

```java
private static final String REPOSITORY_NAME = generateNameWithPrefix(ProcessFailoverIntegrationTest.class.getSimpleName());
```

2.- Configure the GIT settings:

```java
.withGitSettings(GitSettings.fromProperties()
                                                                    .withRepository(REPOSITORY_NAME,
ProcessFailoverIntegrationTest.class.getResource(PROJECT_SOURCE_FOLDER + "/" + DEFINITION_PROJECT_NAME).getFile()))
```

Similarly as the LDAP settings.

3.- Now, when using the GIT provider, we need to use the deployment scenario:

```java
GitProvider gitProvider = deploymentScenario.getGitProvider()
```

3.- Finally, we still need to delete the repository in the after stage since by configuration, the GIT instance might be still using an external service:

```java
@After
    public void tearDown() {
        GitUtils.deleteGitRepository(REPOSITORY_NAME, deploymentScenario);
    }
```