### PR TITLE
BAQE-1296: Check server ID instead of location for kie servers

### DIFF
--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerPersistentScenarioBuilderImpl.java
@@ -162,9 +162,6 @@ public class WorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpe
 
     @Override
     public WorkbenchKieServerPersistentScenarioBuilder usePublicIpAddress() {
-        for (Server server : kieApp.getSpec().getObjects().getServers()) {
-            server.addEnv(new Env(ImageEnvVariables.KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE, Boolean.FALSE.toString()));
-        }
-        return this;
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/WorkbenchKieServerPersistentScenarioLdapIntegrationTest.java
@@ -83,7 +83,6 @@ public class WorkbenchKieServerPersistentScenarioLdapIntegrationTest extends Abs
         deploymentScenario = deploymentScenarioFactory.getWorkbenchKieServerPersistentScenarioBuilder()
                   .withInternalLdap(ldapSettings)
                   .withInternalMavenRepo()
-                  .usePublicIpAddress()
                   .build();
         deploymentScenario
                   .setLogFolderName(WorkbenchKieServerPersistentScenarioLdapIntegrationTest.class.getSimpleName());

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/WorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/sso/WorkbenchKieServerPersistentScenarioSsoIntegrationTest.java
@@ -52,7 +52,6 @@ public class WorkbenchKieServerPersistentScenarioSsoIntegrationTest extends Abst
         deploymentScenario = deploymentScenarioFactory.getWorkbenchKieServerPersistentScenarioBuilder()
                                                       .deploySso()
                                                       .withInternalMavenRepo()
-                                                      .usePublicIpAddress()
                                                       .build();
 
         deploymentScenario.setLogFolderName(WorkbenchKieServerPersistentScenarioSsoIntegrationTest.class.getSimpleName());

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/PersistenceTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/PersistenceTestProvider.java
@@ -70,16 +70,16 @@ public class PersistenceTestProvider {
         KieServicesClient kieServerClient = KieServerClientProvider.getKieServerClient(deploymentScenario.getKieServerDeployment());
 
         KieServerInfo serverInfo = kieServerClient.getServerInfo().getResult();
-        String kieServerLocation = serverInfo.getLocation();
+        String kieServerId = serverInfo.getServerId();
         try {
             WorkbenchUtils.saveContainerSpec(kieControllerClient, serverInfo.getServerId(), serverInfo.getName(), containerId, containerId, Kjar.DEFINITION, KieContainerStatus.STARTED);
             KieServerClientProvider.waitForContainerStart(deploymentScenario.getKieServerDeployment(), containerId);
 
-            verifyOneServerTemplateWithContainer(kieControllerClient, kieServerLocation, containerId);
+            verifyOneServerTemplateWithContainer(kieControllerClient, kieServerId, containerId);
 
             scaleToZeroAndBackToOne(deploymentScenario.getWorkbenchDeployment());
 
-            verifyOneServerTemplateWithContainer(kieControllerClient, kieServerLocation, containerId);
+            verifyOneServerTemplateWithContainer(kieControllerClient, kieServerId, containerId);
         } finally {
             kieControllerClient.deleteContainerSpec(serverInfo.getServerId(), containerId);
         }
@@ -92,13 +92,13 @@ public class PersistenceTestProvider {
         deployment.waitForScale();
     }
 
-    private static void verifyOneServerTemplateWithContainer(KieServerControllerClient kieControllerClient, String kieServerLocation, String containerId) {
+    private static void verifyOneServerTemplateWithContainer(KieServerControllerClient kieControllerClient, String kieServerId, String containerId) {
         ServerTemplateList serverTemplates = kieControllerClient.listServerTemplates();
         assertThat(serverTemplates.getServerTemplates()).as("Number of server templates differ.").hasSize(1);
 
         ServerTemplate serverTemplate = serverTemplates.getServerTemplates()[0];
         assertThat(serverTemplate.getServerInstanceKeys()).hasSize(1);
-        assertThat(serverTemplate.getServerInstanceKeys().iterator().next().getUrl()).isEqualTo(kieServerLocation);
+        assertThat(serverTemplate.getId()).isEqualTo(kieServerId);
         assertThat(serverTemplate.getContainersSpec()).anyMatch(containerSpec -> containerSpec.getId().equals(containerId));
     }
 }


### PR DESCRIPTION
I found out that the property KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE is hardcoded to "true" in the operators (https://github.com/kiegroup/kie-cloud-operator/blob/f92ffb0011ba9eca1040eba57d41e7d70bb462fd/config/7.7.0/common.yaml#L96).

Therefore, I will stop using the "usePublicIpAddress" in a couple of tests and will raise an exception if this method is used when running deployments on operator. 

Also, instead of checking URL/locations, I suggest checking server IDs.