### PR TITLE
BAQE-1332: Add External DB drivers test suite for Operators

### DIFF
--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/ApbExternalDatabase.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/ApbExternalDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,24 +11,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+ */
 package org.kie.cloud.openshift.database.external;
 
-import org.kie.cloud.openshift.database.driver.ExternalDriver;
+import java.util.Map;
 
-/**
- * Represents external database connection for Kie server.
- */
-public interface ExternalDatabase {
+public interface ApbExternalDatabase extends ExternalDatabase {
 
     /**
-     * @return Name of the database driver. It is used by EAP to use correct EJB database initialization scripts.
+     * @return All environment variables required for connection to this database.
      */
-    String getDriverName();
-
-    /**
-     * @return Custom external driver.
-     */
-    ExternalDriver getExternalDriver();
+    Map<String, String> getExternalDatabaseEnvironmentVariables();
 }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/ApbExternalDatabaseProvider.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/ApbExternalDatabaseProvider.java
@@ -15,38 +15,19 @@
 
 package org.kie.cloud.openshift.database.external;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import java.util.Arrays;
 
 public class ApbExternalDatabaseProvider {
 
-    private static Collection<ExternalDatabase> availableExternalDatabases = new ArrayList<>();
+    private static final ExternalDatabaseProvider<ApbExternalDatabase> PROVIDER = new ExternalDatabaseProvider<>(Arrays.asList(new Db2ExternalDatabase(),
+                                                                                                                               new MariaDbExternalDatabase(),
+                                                                                                                               new MssqlExternalDatabase(),
+                                                                                                                               new MySqlExternalDatabase(),
+                                                                                                                               new OracleExternalDatabase(),
+                                                                                                                               new PostgreSqlExternalDatabase(),
+                                                                                                                               new SybaseExternalDatabase()));
 
-    static {
-        availableExternalDatabases.add(new Db2ExternalDatabase());
-        availableExternalDatabases.add(new MariaDbExternalDatabase());
-        availableExternalDatabases.add(new MssqlExternalDatabase());
-        availableExternalDatabases.add(new MySqlExternalDatabase());
-        availableExternalDatabases.add(new OracleExternalDatabase());
-        availableExternalDatabases.add(new PostgreSqlExternalDatabase());
-        availableExternalDatabases.add(new SybaseExternalDatabase());
-    }
-
-    public static ExternalDatabase getExternalDatabase() {
-        String databaseDriver = DeploymentConstants.getDatabaseDriver();
-        if (databaseDriver == null || databaseDriver.isEmpty()) {
-            throw new RuntimeException("System property " + DeploymentConstants.DATABASE_DRIVER + " is not defined. Cannot retrieve external database instance.");
-        }
-
-        return availableExternalDatabases.stream().filter(d -> d.getDriverName().equals(databaseDriver))
-                                                  .findAny()
-                                                  .orElseThrow(() -> {
-                                                      List<String> driverNames = availableExternalDatabases.stream().map(d -> d.getDriverName()).collect(Collectors.toList());
-                                                      return new RuntimeException("External database with driver identifier " + databaseDriver + " is not found. Available driver identifiers: " + driverNames);
-                                                  });
+    public static ApbExternalDatabase getExternalDatabase() {
+        return PROVIDER.getExternalDatabase();
     }
 }

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/Db2ExternalDatabase.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/Db2ExternalDatabase.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 
-public class Db2ExternalDatabase extends AbstractDb2ExternalDatabase {
+public class Db2ExternalDatabase extends AbstractDb2ExternalDatabase implements ApbExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/MariaDbExternalDatabase.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/MariaDbExternalDatabase.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 
-public class MariaDbExternalDatabase extends AbstractMariaDbExternalDatabase  {
+public class MariaDbExternalDatabase extends AbstractMariaDbExternalDatabase implements ApbExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/MssqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/MssqlExternalDatabase.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 
-public class MssqlExternalDatabase extends AbstractMssqlExternalDatabase {
+public class MssqlExternalDatabase extends AbstractMssqlExternalDatabase implements ApbExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/MySqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/MySqlExternalDatabase.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 
-public class MySqlExternalDatabase extends AbstractMySqlExternalDatabase {
+public class MySqlExternalDatabase extends AbstractMySqlExternalDatabase implements ApbExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/OracleExternalDatabase.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/OracleExternalDatabase.java
@@ -21,9 +21,7 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 
-
-public class OracleExternalDatabase extends AbstractOracleExternalDatabase {
-
+public class OracleExternalDatabase extends AbstractOracleExternalDatabase implements ApbExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/PostgreSqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/PostgreSqlExternalDatabase.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 
-public class PostgreSqlExternalDatabase extends AbstractPostgreSqlExternalDatabase {
+public class PostgreSqlExternalDatabase extends AbstractPostgreSqlExternalDatabase implements ApbExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/SybaseExternalDatabase.java
+++ b/framework-cloud/framework-openshift-apb/src/main/java/org/kie/cloud/openshift/database/external/SybaseExternalDatabase.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 
-public class SybaseExternalDatabase extends AbstractSybaseExternalDatabase {
+public class SybaseExternalDatabase extends AbstractSybaseExternalDatabase implements ApbExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/OperatorDeploymentBuilderFactory.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/OperatorDeploymentBuilderFactory.java
@@ -38,6 +38,7 @@ import org.kie.cloud.openshift.operator.scenario.builder.ClusteredWorkbenchKieSe
 import org.kie.cloud.openshift.operator.scenario.builder.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl;
 import org.kie.cloud.openshift.operator.scenario.builder.ImmutableKieServerAmqScenarioBuilderImpl;
 import org.kie.cloud.openshift.operator.scenario.builder.ImmutableKieServerScenarioBuilderImpl;
+import org.kie.cloud.openshift.operator.scenario.builder.KieServerWithExternalDatabaseScenarioBuilderImpl;
 import org.kie.cloud.openshift.operator.scenario.builder.WorkbenchKieServerPersistentScenarioBuilderImpl;
 import org.kie.cloud.openshift.operator.scenario.builder.WorkbenchKieServerScenarioBuilderImpl;
 import org.kie.cloud.openshift.operator.scenario.builder.WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilderImpl;
@@ -78,7 +79,7 @@ public class OperatorDeploymentBuilderFactory implements DeploymentScenarioBuild
 
     @Override
     public KieServerWithExternalDatabaseScenarioBuilder getKieServerWithExternalDatabaseScenarioBuilder() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return new KieServerWithExternalDatabaseScenarioBuilderImpl();
     }
 
     @Override

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/Db2ExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/Db2ExternalDatabase.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.cloud.openshift.operator.database.external;
+
+import org.kie.cloud.openshift.database.external.AbstractDb2ExternalDatabase;
+
+public class Db2ExternalDatabase extends AbstractDb2ExternalDatabase implements OperatorExternalDatabase {
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/MariaDbExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/MariaDbExternalDatabase.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.cloud.openshift.operator.database.external;
+
+import org.kie.cloud.openshift.database.external.AbstractMariaDbExternalDatabase;
+
+public class MariaDbExternalDatabase extends AbstractMariaDbExternalDatabase implements OperatorExternalDatabase {
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/MssqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/MssqlExternalDatabase.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.cloud.openshift.operator.database.external;
+
+import org.kie.cloud.openshift.database.external.AbstractMssqlExternalDatabase;
+
+public class MssqlExternalDatabase extends AbstractMssqlExternalDatabase implements OperatorExternalDatabase {
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/MySqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/MySqlExternalDatabase.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.cloud.openshift.operator.database.external;
+
+import org.kie.cloud.openshift.database.external.AbstractMySqlExternalDatabase;
+
+public class MySqlExternalDatabase extends AbstractMySqlExternalDatabase implements OperatorExternalDatabase {
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/OperatorExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/OperatorExternalDatabase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.operator.database.external;
+
+import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.openshift.database.external.ExternalDatabase;
+import org.kie.cloud.openshift.operator.model.components.Database;
+import org.kie.cloud.openshift.operator.model.components.ExternalConfig;
+
+public interface OperatorExternalDatabase extends ExternalDatabase {
+
+    default Database getDatabaseModel() {
+
+        Database database = new Database();
+        database.setType("external");
+
+        ExternalConfig config = new ExternalConfig();
+        config.setDriver(DeploymentConstants.getDatabaseDriver());
+        config.setDialect(DeploymentConstants.getHibernatePersistenceDialect());
+        config.setHost(DeploymentConstants.getDatabaseHost());
+        config.setPort(DeploymentConstants.getDatabasePort());
+        config.setUsername(DeploymentConstants.getDatabaseUsername());
+        config.setPassword(DeploymentConstants.getDatabasePassword());
+        config.setName(DeploymentConstants.getExternalDatabaseName());
+        database.setExternalConfig(config);
+
+        return database;
+    }
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/OperatorExternalDatabaseProvider.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/OperatorExternalDatabaseProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.cloud.openshift.operator.database.external;
+
+import java.util.Arrays;
+
+import org.kie.cloud.openshift.database.external.ExternalDatabaseProvider;
+
+public class OperatorExternalDatabaseProvider {
+
+    private static final ExternalDatabaseProvider<OperatorExternalDatabase> PROVIDER = new ExternalDatabaseProvider<>(Arrays.asList(new Db2ExternalDatabase(),
+                                                                                                                                  new MariaDbExternalDatabase(),
+                                                                                                                                  new MssqlExternalDatabase(),
+                                                                                                                                  new MySqlExternalDatabase(),
+                                                                                                                                  new OracleExternalDatabase(),
+                                                                                                                                  new PostgreSqlExternalDatabase(),
+                                                                                                                                  new SybaseExternalDatabase()));
+
+    public static OperatorExternalDatabase getExternalDatabase() {
+        return PROVIDER.getExternalDatabase();
+    }
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/OracleExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/OracleExternalDatabase.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.cloud.openshift.operator.database.external;
+
+import org.kie.cloud.openshift.database.external.AbstractOracleExternalDatabase;
+
+public class OracleExternalDatabase extends AbstractOracleExternalDatabase implements OperatorExternalDatabase {
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/PostgreSqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/PostgreSqlExternalDatabase.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.cloud.openshift.operator.database.external;
+
+import org.kie.cloud.openshift.database.external.AbstractPostgreSqlExternalDatabase;
+
+public class PostgreSqlExternalDatabase extends AbstractPostgreSqlExternalDatabase implements OperatorExternalDatabase {
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/SybaseExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/SybaseExternalDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,23 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+package org.kie.cloud.openshift.operator.database.external;
 
-package org.kie.cloud.openshift.database.external;
+import org.kie.cloud.openshift.database.external.AbstractSybaseExternalDatabase;
 
-import org.kie.cloud.openshift.database.driver.ExternalDriver;
+public class SybaseExternalDatabase extends AbstractSybaseExternalDatabase implements OperatorExternalDatabase {
 
-/**
- * Represents external database connection for Kie server.
- */
-public interface ExternalDatabase {
-
-    /**
-     * @return Name of the database driver. It is used by EAP to use correct EJB database initialization scripts.
-     */
-    String getDriverName();
-
-    /**
-     * @return Custom external driver.
-     */
-    ExternalDriver getExternalDriver();
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/components/Build.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/components/Build.java
@@ -27,6 +27,9 @@ public class Build {
     private GitSource gitSource;
     private String kieServerContainerDeployment;
     private String mavenMirrorURL;
+    private String extensionImageStreamTag;
+    private String extensionImageStreamTagNamespace;
+    private String extensionImageInstallDir;
 
     public String getArtifactDir() {
         return artifactDir;
@@ -58,5 +61,29 @@ public class Build {
 
     public void setMavenMirrorURL(String mavenMirrorURL) {
         this.mavenMirrorURL = mavenMirrorURL;
+    }
+
+    public String getExtensionImageStreamTag() {
+        return extensionImageStreamTag;
+    }
+
+    public void setExtensionImageStreamTag(String extensionImageStreamTag) {
+        this.extensionImageStreamTag = extensionImageStreamTag;
+    }
+
+    public String getExtensionImageStreamTagNamespace() {
+        return extensionImageStreamTagNamespace;
+    }
+
+    public void setExtensionImageStreamTagNamespace(String extensionImageStreamTagNamespace) {
+        this.extensionImageStreamTagNamespace = extensionImageStreamTagNamespace;
+    }
+
+    public String getExtensionImageInstallDir() {
+        return extensionImageInstallDir;
+    }
+
+    public void setExtensionImageInstallDir(String extensionImageInstallDir) {
+        this.extensionImageInstallDir = extensionImageInstallDir;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/components/Database.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/components/Database.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.operator.model.components;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Database {
+
+    private String type;
+    private ExternalConfig externalConfig;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public ExternalConfig getExternalConfig() {
+        return externalConfig;
+    }
+
+    public void setExternalConfig(ExternalConfig externalConfig) {
+        this.externalConfig = externalConfig;
+    }
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/components/ExternalConfig.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/components/ExternalConfig.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.operator.model.components;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ExternalConfig {
+
+    private String name;
+    private String driver;
+    private String dialect;
+    private String jdbcURL;
+    private String host;
+    private String port;
+    private String username;
+    private String password;
+    private String minPoolSize;
+    private String maxPoolSize;
+    private String connectionChecker;
+    private String exceptionSorter;
+    private String backgroundValidation;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDriver() {
+        return driver;
+    }
+
+    public void setDriver(String driver) {
+        this.driver = driver;
+    }
+
+    public String getDialect() {
+        return dialect;
+    }
+
+    public void setDialect(String dialect) {
+        this.dialect = dialect;
+    }
+
+    public String getJdbcURL() {
+        return jdbcURL;
+    }
+
+    public void setJdbcURL(String jdbcURL) {
+        this.jdbcURL = jdbcURL;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getPort() {
+        return port;
+    }
+
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getMinPoolSize() {
+        return minPoolSize;
+    }
+
+    public void setMinPoolSize(String minPoolSize) {
+        this.minPoolSize = minPoolSize;
+    }
+
+    public String getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public void setMaxPoolSize(String maxPoolSize) {
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public String getConnectionChecker() {
+        return connectionChecker;
+    }
+
+    public void setConnectionChecker(String connectionChecker) {
+        this.connectionChecker = connectionChecker;
+    }
+
+    public String getBackgroundValidation() {
+        return backgroundValidation;
+    }
+
+    public void setBackgroundValidation(String backgroundValidation) {
+        this.backgroundValidation = backgroundValidation;
+    }
+
+    public String getExceptionSorter() {
+        return exceptionSorter;
+    }
+
+    public void setExceptionSorter(String exceptionSorter) {
+        this.exceptionSorter = exceptionSorter;
+    }
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/components/Server.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/components/Server.java
@@ -36,6 +36,7 @@ public class Server {
     private Resources resources;
     private Build build;
     private Jms jms;
+    private Database database;
 
     public String getName() {
         return name;
@@ -115,5 +116,13 @@ public class Server {
 
     public void setJms(Jms jms) {
         this.jms = jms;
+    }
+
+    public Database getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(Database database) {
+        this.database = database;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/KieServerWithExternalDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/KieServerWithExternalDatabaseScenarioImpl.java
@@ -62,7 +62,7 @@ public class KieServerWithExternalDatabaseScenarioImpl extends OpenShiftOperator
 
         dockerDeployment = DockerRegistryDeployer.deploy(project);
 
-        // Create image stream from external image with driver and reference it for template
+        // Create image stream from external image with driver and reference it for custom resource
         installDriverImageToRegistry(dockerDeployment, externalDatabase.getExternalDriver());
         createDriverImageStreams(dockerDeployment, externalDatabase.getExternalDriver());
         String extensionImage = externalDatabase.getExternalDriver().getImageName() + ":" + externalDatabase.getExternalDriver().getImageVersion();

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/KieServerWithExternalDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/KieServerWithExternalDatabaseScenarioImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,17 +11,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
-package org.kie.cloud.openshift.scenario;
+ */
+package org.kie.cloud.openshift.operator.scenario;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import cz.xtf.core.waiting.SimpleWaiter;
+import cz.xtf.core.waiting.WaiterException;
 import org.kie.cloud.api.deployment.ControllerDeployment;
 import org.kie.cloud.api.deployment.Deployment;
 import org.kie.cloud.api.deployment.DockerDeployment;
@@ -30,61 +31,66 @@ import org.kie.cloud.api.deployment.SmartRouterDeployment;
 import org.kie.cloud.api.deployment.WorkbenchDeployment;
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
-import org.kie.cloud.openshift.constants.OpenShiftApbConstants;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
-import org.kie.cloud.openshift.database.external.ApbExternalDatabase;
-import org.kie.cloud.openshift.database.external.ApbExternalDatabaseProvider;
 import org.kie.cloud.openshift.deployment.KieServerDeploymentImpl;
-import org.kie.cloud.openshift.deployment.external.ExternalDeployment;
-import org.kie.cloud.openshift.deployment.external.ExternalDeploymentApb;
-import org.kie.cloud.openshift.template.OpenShiftTemplate;
-import org.kie.cloud.openshift.util.ApbImageGetter;
+import org.kie.cloud.openshift.operator.database.external.OperatorExternalDatabase;
+import org.kie.cloud.openshift.operator.database.external.OperatorExternalDatabaseProvider;
+import org.kie.cloud.openshift.operator.deployment.KieServerOperatorDeployment;
+import org.kie.cloud.openshift.operator.model.KieApp;
+import org.kie.cloud.openshift.operator.model.components.Build;
+import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.util.DockerRegistryDeployer;
 import org.kie.cloud.openshift.util.ProcessExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KieServerWithExternalDatabaseScenarioApb extends OpenShiftScenario<KieServerWithExternalDatabaseScenario> implements KieServerWithExternalDatabaseScenario {
+public class KieServerWithExternalDatabaseScenarioImpl extends OpenShiftOperatorScenario<KieServerWithExternalDatabaseScenario> implements KieServerWithExternalDatabaseScenario {
+
+    private static final Logger logger = LoggerFactory.getLogger(KieServerWithExternalDatabaseScenarioImpl.class);
 
     private KieServerDeploymentImpl kieServerDeployment;
     private DockerDeployment dockerDeployment;
-    private Map<String, String> extraVars;
 
-    private static final Logger logger = LoggerFactory.getLogger(KieServerWithExternalDatabaseScenario.class);
-
-    public KieServerWithExternalDatabaseScenarioApb(Map<String, String> extraVars) {
-        this.extraVars = extraVars;
+    public KieServerWithExternalDatabaseScenarioImpl(KieApp kieApp) {
+        super(kieApp);
     }
 
     @Override
-    public KieServerDeployment getKieServerDeployment() {
-        return kieServerDeployment;
-    }
-
-    @Override
-    protected void deployKieDeployments() {
-        ApbExternalDatabase externalDatabase = ApbExternalDatabaseProvider.getExternalDatabase();
-        extraVars.putAll(externalDatabase.getExternalDatabaseEnvironmentVariables());
+    protected void deployCustomResource() {
+        OperatorExternalDatabase externalDatabase = OperatorExternalDatabaseProvider.getExternalDatabase();
 
         dockerDeployment = DockerRegistryDeployer.deploy(project);
 
         // Create image stream from external image with driver and reference it for template
         installDriverImageToRegistry(dockerDeployment, externalDatabase.getExternalDriver());
         createDriverImageStreams(dockerDeployment, externalDatabase.getExternalDriver());
+        String extensionImage = externalDatabase.getExternalDriver().getImageName() + ":" + externalDatabase.getExternalDriver().getImageVersion();
 
-        logger.info("Creating trusted secret");
-        deployCustomTrustedSecret();
+        for (Server server : kieApp.getSpec().getObjects().getServers()) {
+            if (server.getBuild() == null) {
+                server.setBuild(new Build());
+            }
 
-        logger.info("Processesin APB image plan: " + extraVars.get(OpenShiftApbConstants.APB_PLAN_ID));
-        extraVars.put(OpenShiftApbConstants.IMAGE_STREAM_NAMESPACE, projectName);
-        extraVars.put("namespace", projectName);
-        extraVars.put("cluster", "openshift");
-        project.processApbRun(ApbImageGetter.fromImageStream(), extraVars);
+            server.getBuild().setExtensionImageStreamTag(extensionImage);
+            server.getBuild().setExtensionImageStreamTagNamespace(project.getName());
+            server.setDatabase(externalDatabase.getDatabaseModel());
+            registerCustomTrustedSecret(server);
+        }
 
-        kieServerDeployment = new KieServerDeploymentImpl(project);
+        // deploy application
+        getKieAppClient().create(kieApp);
+
+        kieServerDeployment = new KieServerOperatorDeployment(project, getKieAppClient());
         kieServerDeployment.setUsername(DeploymentConstants.getAppUser());
         kieServerDeployment.setPassword(DeploymentConstants.getAppPassword());
+
+        logger.info("Waiting until all services are created.");
+        try {
+            new SimpleWaiter(() -> kieServerDeployment.isReady()).reason("Waiting for Kie server service to be created.").timeout(TimeUnit.MINUTES, 1).waitFor();
+        } catch (WaiterException e) {
+            throw new RuntimeException("Timeout while deploying application.", e);
+        }
 
         logger.info("Waiting for Kie server deployment to become ready.");
         kieServerDeployment.waitForScale();
@@ -93,20 +99,13 @@ public class KieServerWithExternalDatabaseScenarioApb extends OpenShiftScenario<
     }
 
     @Override
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    protected void configureWithExternalDeployment(ExternalDeployment<?, ?> externalDeployment) {
-        ((ExternalDeploymentApb) externalDeployment).configure(extraVars);
-    }
-
-    @Override
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    protected void removeConfigurationFromExternalDeployment(ExternalDeployment<?, ?> externalDeployment) {
-        ((ExternalDeploymentApb) externalDeployment).removeConfiguration(extraVars);
+    public KieServerDeployment getKieServerDeployment() {
+        return kieServerDeployment;
     }
 
     @Override
     public List<Deployment> getDeployments() {
-        List<Deployment> deployments = new ArrayList<Deployment>(Arrays.asList(kieServerDeployment, dockerDeployment));
+        List<Deployment> deployments = new ArrayList<>(Arrays.asList(kieServerDeployment, dockerDeployment));
         deployments.removeAll(Collections.singleton(null));
         return deployments;
     }
@@ -151,16 +150,7 @@ public class KieServerWithExternalDatabaseScenarioApb extends OpenShiftScenario<
         String imageStreamName = externalDriver.getImageName();
         String dockerTag = externalDriver.getTargetDockerTag(dockerDeployment.getUrl());
 
-        project.createImageStream(imageStreamName, dockerTag);
+        project.createImageStreamFromInsecureRegistry(imageStreamName, dockerTag);
     }
 
-    private void deployCustomTrustedSecret() {
-        project.processTemplateAndCreateResources(OpenShiftTemplate.CUSTOM_TRUSTED_SECRET.getTemplateUrl(),
-                Collections.emptyMap());
-
-        extraVars.put(OpenShiftApbConstants.KIESERVER_SECRET_NAME, DeploymentConstants.getCustomTrustedSecretName());
-        extraVars.put(OpenShiftApbConstants.KIESERVER_KEYSTORE_ALIAS,
-                DeploymentConstants.getCustomTrustedKeystoreAlias());
-        extraVars.put(OpenShiftApbConstants.KIESERVER_KEYSTORE_PWD, DeploymentConstants.getCustomTrustedKeystorePwd());
-    }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/AbstractTrialOpenshiftScenarioBuilderOperator.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/AbstractTrialOpenshiftScenarioBuilderOperator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.operator.scenario.builder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+import org.kie.cloud.openshift.constants.ImageEnvVariables;
+import org.kie.cloud.openshift.constants.OpenShiftConstants;
+import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorConstants;
+import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorEnvironments;
+import org.kie.cloud.openshift.operator.model.KieApp;
+import org.kie.cloud.openshift.operator.model.components.CommonConfig;
+import org.kie.cloud.openshift.operator.model.components.Console;
+import org.kie.cloud.openshift.operator.model.components.Env;
+import org.kie.cloud.openshift.operator.model.components.ImageRegistry;
+import org.kie.cloud.openshift.operator.model.components.Server;
+
+public abstract class AbstractTrialOpenshiftScenarioBuilderOperator<T> extends AbstractOpenshiftScenarioBuilderOperator<T> {
+
+    private KieApp kieApp = new KieApp();
+
+    public AbstractTrialOpenshiftScenarioBuilderOperator() {
+        List<Env> authenticationEnvVars = new ArrayList<>();
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
+        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_PWD, DeploymentConstants.getAppPassword()));
+
+        kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
+        kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.TRIAL);
+        kieApp.getSpec().setUseImageTags(true);
+
+        OpenShiftOperatorConstants.getKieImageRegistryCustom().ifPresent(registry -> {
+            ImageRegistry imageRegistry = new ImageRegistry();
+            imageRegistry.setInsecure(true);
+            imageRegistry.setRegistry(registry);
+            kieApp.getSpec().setImageRegistry(imageRegistry);
+        });
+
+        CommonConfig commonConfig = new CommonConfig();
+        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
+        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
+        kieApp.getSpec().setCommonConfig(commonConfig);
+
+        Server server = new Server();
+        server.setName(OpenShiftConstants.getKieApplicationName() + "-kieserver");
+        server.addEnvs(authenticationEnvVars);
+        kieApp.getSpec().getObjects().addServer(server);
+
+        Console console = new Console();
+        console.addEnvs(authenticationEnvVars);
+        kieApp.getSpec().getObjects().setConsole(console);
+    }
+
+    public KieApp getKieApp() {
+        return kieApp;
+    }
+
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/KieServerWithExternalDatabaseScenarioBuilderImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.operator.scenario.builder;
+
+import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
+import org.kie.cloud.api.scenario.builder.KieServerWithExternalDatabaseScenarioBuilder;
+import org.kie.cloud.openshift.constants.ImageEnvVariables;
+import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
+import org.kie.cloud.openshift.operator.model.components.Env;
+import org.kie.cloud.openshift.operator.model.components.Server;
+import org.kie.cloud.openshift.operator.scenario.KieServerWithExternalDatabaseScenarioImpl;
+
+public class KieServerWithExternalDatabaseScenarioBuilderImpl extends AbstractTrialOpenshiftScenarioBuilderOperator<KieServerWithExternalDatabaseScenario> implements KieServerWithExternalDatabaseScenarioBuilder {
+
+    @Override
+    public KieServerWithExternalDatabaseScenarioBuilder withInternalMavenRepo(boolean waitForRunning) {
+        setAsyncExternalDeployment(ExternalDeploymentID.MAVEN_REPOSITORY);
+        return this;
+    }
+
+    @Override
+    public KieServerWithExternalDatabaseScenarioBuilder withKieServerId(String kieServerId) {
+        for (Server server : getKieApp().getSpec().getObjects().getServers()) {
+            server.addEnv(new Env(ImageEnvVariables.KIE_SERVER_ID, kieServerId));
+        }
+
+        return this;
+    }
+
+    @Override
+    protected KieServerWithExternalDatabaseScenario getDeploymentScenarioInstance() {
+        return new KieServerWithExternalDatabaseScenarioImpl(getKieApp());
+    }
+
+}

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchKieServerScenarioBuilderImpl.java
@@ -16,62 +16,22 @@
 package org.kie.cloud.openshift.operator.scenario.builder;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 
-import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.api.scenario.WorkbenchKieServerScenario;
 import org.kie.cloud.api.scenario.builder.WorkbenchKieServerScenarioBuilder;
 import org.kie.cloud.openshift.constants.ImageEnvVariables;
-import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
-import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorConstants;
-import org.kie.cloud.openshift.operator.constants.OpenShiftOperatorEnvironments;
-import org.kie.cloud.openshift.operator.model.KieApp;
-import org.kie.cloud.openshift.operator.model.components.CommonConfig;
-import org.kie.cloud.openshift.operator.model.components.Console;
 import org.kie.cloud.openshift.operator.model.components.Env;
-import org.kie.cloud.openshift.operator.model.components.ImageRegistry;
 import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.scenario.WorkbenchKieServerScenarioImpl;
 
-public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<WorkbenchKieServerScenario> implements WorkbenchKieServerScenarioBuilder {
+public class WorkbenchKieServerScenarioBuilderImpl extends AbstractTrialOpenshiftScenarioBuilderOperator<WorkbenchKieServerScenario> implements WorkbenchKieServerScenarioBuilder {
 
-    private KieApp kieApp = new KieApp();
     private boolean deployPrometheus = false;
-
-    public WorkbenchKieServerScenarioBuilderImpl() {
-        List<Env> authenticationEnvVars = new ArrayList<>();
-        authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
-
-        kieApp.getMetadata().setName(OpenShiftConstants.getKieApplicationName());
-        kieApp.getSpec().setEnvironment(OpenShiftOperatorEnvironments.TRIAL);
-        kieApp.getSpec().setUseImageTags(true);
-
-        OpenShiftOperatorConstants.getKieImageRegistryCustom().ifPresent(registry -> {
-            ImageRegistry imageRegistry = new ImageRegistry();
-            imageRegistry.setInsecure(true);
-            imageRegistry.setRegistry(registry);
-            kieApp.getSpec().setImageRegistry(imageRegistry);
-        });
-
-        CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setAdminUser(DeploymentConstants.getAppUser());
-        commonConfig.setAdminPassword(DeploymentConstants.getAppPassword());
-        kieApp.getSpec().setCommonConfig(commonConfig);
-
-        Server server = new Server();
-        server.addEnvs(authenticationEnvVars);
-        kieApp.getSpec().getObjects().addServer(server);
-
-        Console console = new Console();
-        console.addEnvs(authenticationEnvVars);
-        kieApp.getSpec().getObjects().setConsole(console);
-    }
 
     @Override
     public WorkbenchKieServerScenario getDeploymentScenarioInstance() {
-        return new WorkbenchKieServerScenarioImpl(kieApp, deployPrometheus);
+        return new WorkbenchKieServerScenarioImpl(getKieApp(), deployPrometheus);
     }
 
     @Override
@@ -82,7 +42,7 @@ public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
 
     @Override
     public WorkbenchKieServerScenarioBuilder withKieServerId(String kieServerId) {
-        for (Server server : kieApp.getSpec().getObjects().getServers()) {
+        for (Server server : getKieApp().getSpec().getObjects().getServers()) {
             server.addEnv(new Env(ImageEnvVariables.KIE_SERVER_ID, kieServerId));
         }
         return this;
@@ -116,7 +76,7 @@ public class WorkbenchKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
     @Override
     public WorkbenchKieServerScenarioBuilder withPrometheusMonitoring() {
         deployPrometheus = true;
-        for (Server server : kieApp.getSpec().getObjects().getServers()) {
+        for (Server server : getKieApp().getSpec().getObjects().getServers()) {
             server.addEnv(new Env(ImageEnvVariables.PROMETHEUS_SERVER_EXT_DISABLED, "false"));
         }
         return this;

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/Db2ExternalDatabase.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/Db2ExternalDatabase.java
@@ -18,10 +18,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
-import org.kie.cloud.openshift.database.external.AbstractDb2ExternalDatabase;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 
-public class Db2ExternalDatabase extends AbstractDb2ExternalDatabase {
+public class Db2ExternalDatabase extends AbstractDb2ExternalDatabase implements TemplateExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/MariaDbExternalDatabase.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/MariaDbExternalDatabase.java
@@ -20,9 +20,8 @@ import java.util.Map;
 
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
-import org.kie.cloud.openshift.database.external.AbstractMariaDbExternalDatabase;
 
-public class MariaDbExternalDatabase extends AbstractMariaDbExternalDatabase  {
+public class MariaDbExternalDatabase extends AbstractMariaDbExternalDatabase implements TemplateExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/MssqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/MssqlExternalDatabase.java
@@ -20,9 +20,8 @@ import java.util.Map;
 
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
-import org.kie.cloud.openshift.database.external.AbstractMssqlExternalDatabase;
 
-public class MssqlExternalDatabase extends AbstractMssqlExternalDatabase {
+public class MssqlExternalDatabase extends AbstractMssqlExternalDatabase implements TemplateExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/MySqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/MySqlExternalDatabase.java
@@ -19,10 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
-import org.kie.cloud.openshift.database.external.AbstractMySqlExternalDatabase;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 
-public class MySqlExternalDatabase extends AbstractMySqlExternalDatabase {
+public class MySqlExternalDatabase extends AbstractMySqlExternalDatabase implements TemplateExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/OracleExternalDatabase.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/OracleExternalDatabase.java
@@ -19,12 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
-import org.kie.cloud.openshift.database.external.AbstractOracleExternalDatabase;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 
-
-public class OracleExternalDatabase extends AbstractOracleExternalDatabase {
-
+public class OracleExternalDatabase extends AbstractOracleExternalDatabase implements TemplateExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/PostgreSqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/PostgreSqlExternalDatabase.java
@@ -19,10 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
-import org.kie.cloud.openshift.database.external.AbstractPostgreSqlExternalDatabase;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 
-public class PostgreSqlExternalDatabase extends AbstractPostgreSqlExternalDatabase {
+public class PostgreSqlExternalDatabase extends AbstractPostgreSqlExternalDatabase implements TemplateExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/SybaseExternalDatabase.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/SybaseExternalDatabase.java
@@ -20,9 +20,8 @@ import java.util.Map;
 
 import org.kie.cloud.api.deployment.constants.DeploymentConstants;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
-import org.kie.cloud.openshift.database.external.AbstractSybaseExternalDatabase;
 
-public class SybaseExternalDatabase extends AbstractSybaseExternalDatabase {
+public class SybaseExternalDatabase extends AbstractSybaseExternalDatabase implements TemplateExternalDatabase {
 
     @Override
     public Map<String, String> getExternalDatabaseEnvironmentVariables() {

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/TemplateExternalDatabase.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/TemplateExternalDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,24 +11,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+ */
 package org.kie.cloud.openshift.database.external;
 
-import org.kie.cloud.openshift.database.driver.ExternalDriver;
+import java.util.Map;
 
-/**
- * Represents external database connection for Kie server.
- */
-public interface ExternalDatabase {
+public interface TemplateExternalDatabase extends ExternalDatabase {
 
     /**
-     * @return Name of the database driver. It is used by EAP to use correct EJB database initialization scripts.
+     * @return All environment variables required for connection to this database.
      */
-    String getDriverName();
-
-    /**
-     * @return Custom external driver.
-     */
-    ExternalDriver getExternalDriver();
+    Map<String, String> getExternalDatabaseEnvironmentVariables();
 }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/TemplateExternalDatabaseProvider.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/TemplateExternalDatabaseProvider.java
@@ -15,39 +15,19 @@
 
 package org.kie.cloud.openshift.database.external;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.kie.cloud.api.deployment.constants.DeploymentConstants;
-import org.kie.cloud.openshift.database.external.ExternalDatabase;
+import java.util.Arrays;
 
 public class TemplateExternalDatabaseProvider {
 
-    private static Collection<ExternalDatabase> availableExternalDatabases = new ArrayList<>();
+    private static final ExternalDatabaseProvider<TemplateExternalDatabase> PROVIDER = new ExternalDatabaseProvider<>(Arrays.asList(new Db2ExternalDatabase(),
+                                                                                                                                    new MariaDbExternalDatabase(),
+                                                                                                                                    new MssqlExternalDatabase(),
+                                                                                                                                    new MySqlExternalDatabase(),
+                                                                                                                                    new OracleExternalDatabase(),
+                                                                                                                                    new PostgreSqlExternalDatabase(),
+                                                                                                                                    new SybaseExternalDatabase()));
 
-    static {
-        availableExternalDatabases.add(new Db2ExternalDatabase());
-        availableExternalDatabases.add(new MariaDbExternalDatabase());
-        availableExternalDatabases.add(new MssqlExternalDatabase());
-        availableExternalDatabases.add(new MySqlExternalDatabase());
-        availableExternalDatabases.add(new OracleExternalDatabase());
-        availableExternalDatabases.add(new PostgreSqlExternalDatabase());
-        availableExternalDatabases.add(new SybaseExternalDatabase());
-    }
-
-    public static ExternalDatabase getExternalDatabase() {
-        String databaseDriver = DeploymentConstants.getDatabaseDriver();
-        if (databaseDriver == null || databaseDriver.isEmpty()) {
-            throw new RuntimeException("System property " + DeploymentConstants.DATABASE_DRIVER + " is not defined. Cannot retrieve external database instance.");
-        }
-
-        return availableExternalDatabases.stream().filter(d -> d.getDriverName().equals(databaseDriver))
-                                                  .findAny()
-                                                  .orElseThrow(() -> {
-                                                      List<String> driverNames = availableExternalDatabases.stream().map(d -> d.getDriverName()).collect(Collectors.toList());
-                                                      return new RuntimeException("External database with driver identifier " + databaseDriver + " is not found. Available driver identifiers: " + driverNames);
-                                                  });
+    public static TemplateExternalDatabase getExternalDatabase() {
+        return PROVIDER.getExternalDatabase();
     }
 }

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/KieServerWithExternalDatabaseScenarioImpl.java
@@ -33,7 +33,7 @@ import org.kie.cloud.api.scenario.KieServerWithExternalDatabaseScenario;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
 import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.database.driver.ExternalDriver;
-import org.kie.cloud.openshift.database.external.ExternalDatabase;
+import org.kie.cloud.openshift.database.external.TemplateExternalDatabase;
 import org.kie.cloud.openshift.database.external.TemplateExternalDatabaseProvider;
 import org.kie.cloud.openshift.deployment.KieServerDeploymentImpl;
 import org.kie.cloud.openshift.template.OpenShiftTemplate;
@@ -59,7 +59,7 @@ public class KieServerWithExternalDatabaseScenarioImpl extends KieCommonScenario
 
     @Override
     protected void deployKieDeployments() {
-        ExternalDatabase externalDatabase = TemplateExternalDatabaseProvider.getExternalDatabase();
+        TemplateExternalDatabase externalDatabase = TemplateExternalDatabaseProvider.getExternalDatabase();
         envVariables.putAll(externalDatabase.getExternalDatabaseEnvironmentVariables());
 
         dockerDeployment = DockerRegistryDeployer.deploy(project);

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/ExternalDatabaseProvider.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/external/ExternalDatabaseProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.database.external;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.kie.cloud.api.deployment.constants.DeploymentConstants;
+
+public class ExternalDatabaseProvider<T extends ExternalDatabase> {
+
+    private final Collection<T> availableExternalDatabases;
+
+    public ExternalDatabaseProvider(Collection<T> databases) {
+        this.availableExternalDatabases = Collections.unmodifiableCollection(databases);
+    }
+
+    public T getExternalDatabase() {
+        String databaseDriver = DeploymentConstants.getDatabaseDriver();
+        if (databaseDriver == null || databaseDriver.isEmpty()) {
+            throw new RuntimeException("System property " + DeploymentConstants.DATABASE_DRIVER + " is not defined. Cannot retrieve external database instance.");
+        }
+
+        return availableExternalDatabases.stream().filter(d -> d.getDriverName().equals(databaseDriver))
+                                         .findAny()
+                                         .orElseThrow(() -> {
+                                             List<String> driverNames = availableExternalDatabases.stream().map(d -> d.getDriverName()).collect(Collectors.toList());
+                                             return new RuntimeException("External database with driver identifier " + databaseDriver + " is not found. Available driver identifiers: " + driverNames);
+                                         });
+    }
+
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
@@ -131,6 +131,14 @@ public interface Project extends AutoCloseable {
     public void createImageStream(String imageStreamName, String imageTag);
 
     /**
+     * Create image stream in current project from an insecure registry.
+     *
+     * @param imageStreamName Name of image stream
+     * @param imageTag Image tag used to resolve image,for example Docker tag.
+     */
+    public void createImageStreamFromInsecureRegistry(String imageStreamName, String imageTag);
+
+    /**
      * Run oc command
      * @param args Command parameters
      * @return Output of oc

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import cz.xtf.builder.builders.ImageStreamBuilder;
+import cz.xtf.builder.builders.ImageStreamBuilder.TagReferencePolicyType;
 import cz.xtf.builder.builders.SecretBuilder;
 import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShiftBinary;
@@ -269,8 +270,17 @@ public class ProjectImpl implements Project {
 
     @Override
     public void createImageStream(String imageStreamName, String imageTag) {
-        ImageStream driverImageStream = new ImageStreamBuilder(imageStreamName).fromExternalImage(imageTag).build();
-        openShift.createImageStream(driverImageStream);
+        ImageStream imageStream = new ImageStreamBuilder(imageStreamName).fromExternalImage(imageTag).build();
+        openShift.createImageStream(imageStream);
+    }
+
+    @Override
+    public void createImageStreamFromInsecureRegistry(String imageStreamName, String imageTag) {
+        ImageStream imageStream = new ImageStreamBuilder(imageStreamName).insecure().fromExternalImage(imageTag).build();
+        imageStream.getSpec().getTags().forEach(tag -> {
+            tag.getReferencePolicy().setType(TagReferencePolicyType.LOCAL.toString());
+        });
+        openShift.createImageStream(imageStream);
     }
 
     @Override


### PR DESCRIPTION
In order to avoid regression issues, I run the DB job for templates: https://rhba-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/jcarvaja/job/jcarvaja-openshift-db-templates/7/

And I checked the DB job for operators which now works fine (in the same engines as in templates): https://rhba-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/jcarvaja/job/jcarvaja-openshift-db-operator/40/