### PR TITLE
BAQE-1336: Avoid to wait for routes when we scale down to 0 a deployment

### DIFF
--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/OpenShiftDeployment.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/OpenShiftDeployment.java
@@ -130,7 +130,7 @@ public abstract class OpenShiftDeployment implements Deployment {
 
     @Override
     public List<Instance> getInstances() {
-        if (isReady()) {
+        if (isReady() && getReplicas() > 0) {
             String deploymentConfigName = getDeploymentConfigName();
 
             return OpenShiftCaller.repeatableCall(() -> openShift.getPods()


### PR DESCRIPTION
The getInstances method sometimes returns the list of instances even when the replicas is 0.
This used to happen when we scale down to zero a deployment (but not happens all the times).

Adding this condition will save some time in the scaling test suites. 

I've tested already using WorkbenchPersistenceIntegrationTest.