### PR TITLE
BAQE-1325: Mark tests that require missing properties as Ignored in RHDM

### DIFF
--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl.java
@@ -40,7 +40,8 @@ import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.ClusteredWorkbenchKieServerDatabasePersistentScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
 import org.kie.cloud.openshift.scenario.ScenarioRequest;
-import org.kie.cloud.openshift.template.ProjectProfile;
+
+import static org.kie.cloud.openshift.util.ScenarioValidations.verifyJbpmScenarioOnly;
 
 public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<ClusteredWorkbenchKieServerDatabasePersistentScenario> implements
                                                                               ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder {
@@ -49,7 +50,7 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
     private final ScenarioRequest request = new ScenarioRequest();
 
     public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl() {
-        isScenarioAllowed();
+        verifyJbpmScenarioOnly();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
         authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
@@ -165,18 +166,6 @@ public class ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilderImpl ex
     public ClusteredWorkbenchKieServerDatabasePersistentScenarioBuilder withInternalLdap(LdapSettings ldapSettings) {
         setAsyncExternalDeployment(ExternalDeploymentID.LDAP);
         return withExternalLdap(ldapSettings);
-    }
-
-    private static void isScenarioAllowed() {
-        ProjectProfile projectProfile = ProjectProfile.fromSystemProperty();
-        switch (projectProfile) {
-            case JBPM:
-                return;
-            case DROOLS:
-                throw new UnsupportedOperationException("Not supported");
-            default:
-                throw new IllegalStateException("Unrecognized ProjectProfile: " + projectProfile);
-        }
     }
 
     @Override

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl.java
@@ -34,7 +34,8 @@ import org.kie.cloud.openshift.operator.model.components.ImageRegistry;
 import org.kie.cloud.openshift.operator.model.components.Server;
 import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.ClusteredWorkbenchKieServerPersistentScenarioImpl;
-import org.kie.cloud.openshift.template.ProjectProfile;
+
+import static org.kie.cloud.openshift.util.ScenarioValidations.verifyDroolsScenarioOnly;
 
 public class ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<ClusteredWorkbenchKieServerPersistentScenario> implements
                                                                       ClusteredWorkbenchKieServerPersistentScenarioBuilder {
@@ -43,7 +44,7 @@ public class ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl extends Ab
     private boolean deploySSO = false;
 
     public ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl() {
-        isScenarioAllowed();
+        verifyDroolsScenarioOnly();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
         authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
@@ -110,18 +111,6 @@ public class ClusteredWorkbenchKieServerPersistentScenarioBuilderImpl extends Ab
             servers[i].setSsoClient(ssoClient);
         }
         return this;
-    }
-
-    private static void isScenarioAllowed() {
-        ProjectProfile projectProfile = ProjectProfile.fromSystemProperty();
-        switch (projectProfile) {
-            case JBPM:
-                throw new UnsupportedOperationException("Not supported");
-            case DROOLS:
-                return;
-            default:
-                throw new IllegalStateException("Unrecognized ProjectProfile: " + projectProfile);
-        }
     }
 
     @Override

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl.java
@@ -40,7 +40,8 @@ import org.kie.cloud.openshift.operator.model.components.SmartRouter;
 import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
-import org.kie.cloud.openshift.template.ProjectProfile;
+
+import static org.kie.cloud.openshift.util.ScenarioValidations.verifyJbpmScenarioOnly;
 
 public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenario>
                                                                                               implements ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder {
@@ -49,7 +50,7 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
     private boolean deploySSO = false;
 
     public ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilderImpl() {
-        isScenarioAllowed();
+        verifyJbpmScenarioOnly();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
         authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
@@ -189,17 +190,5 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
     public ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioBuilder withInternalLdap(LdapSettings ldapSettings) {
         setAsyncExternalDeployment(ExternalDeploymentID.LDAP);
         return withExternalLdap(ldapSettings);
-    }
-
-    private static void isScenarioAllowed() {
-        ProjectProfile projectProfile = ProjectProfile.fromSystemProperty();
-        switch (projectProfile) {
-            case JBPM:
-                return;
-            case DROOLS:
-                throw new UnsupportedOperationException("Not supported");
-            default:
-                throw new IllegalStateException("Unrecognized ProjectProfile: " + projectProfile);
-        }
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerAmqScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerAmqScenarioBuilderImpl.java
@@ -43,7 +43,8 @@ import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.ImmutableKieServerAmqScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
 import org.kie.cloud.openshift.scenario.ScenarioRequest;
-import org.kie.cloud.openshift.template.ProjectProfile;
+
+import static org.kie.cloud.openshift.util.ScenarioValidations.verifyDroolsScenarioOnly;
 
 public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<ImmutableKieServerAmqScenario> implements ImmutableKieServerAmqScenarioBuilder {
 
@@ -51,7 +52,7 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftS
     private ScenarioRequest request = new ScenarioRequest();
 
     public ImmutableKieServerAmqScenarioBuilderImpl() {
-        isScenarioAllowed();
+        verifyDroolsScenarioOnly();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
         authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
@@ -215,17 +216,5 @@ public class ImmutableKieServerAmqScenarioBuilderImpl extends AbstractOpenshiftS
         }
 
         return this;
-    }
-
-    private static void isScenarioAllowed() {
-        ProjectProfile projectProfile = ProjectProfile.fromSystemProperty();
-        switch (projectProfile) {
-            case JBPM:
-                throw new UnsupportedOperationException("Not supported");
-            case DROOLS:
-                return;
-            default:
-                throw new IllegalStateException("Unrecognized ProjectProfile: " + projectProfile);
-        }
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/ImmutableKieServerScenarioBuilderImpl.java
@@ -42,7 +42,8 @@ import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.ImmutableKieServerScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
 import org.kie.cloud.openshift.scenario.ScenarioRequest;
-import org.kie.cloud.openshift.template.ProjectProfile;
+
+import static org.kie.cloud.openshift.util.ScenarioValidations.verifyDroolsScenarioOnly;
 
 public class ImmutableKieServerScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<ImmutableKieServerScenario> implements ImmutableKieServerScenarioBuilder {
 
@@ -50,7 +51,7 @@ public class ImmutableKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
     private ScenarioRequest request = new ScenarioRequest();
 
     public ImmutableKieServerScenarioBuilderImpl() {
-        isScenarioAllowed();
+        verifyDroolsScenarioOnly();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
         authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
@@ -202,17 +203,5 @@ public class ImmutableKieServerScenarioBuilderImpl extends AbstractOpenshiftScen
         }
 
         return this;
-    }
-
-    private static void isScenarioAllowed() {
-        ProjectProfile projectProfile = ProjectProfile.fromSystemProperty();
-        switch (projectProfile) {
-            case JBPM:
-                throw new UnsupportedOperationException("Not supported");
-            case DROOLS:
-                return;
-            default:
-                throw new IllegalStateException("Unrecognized ProjectProfile: " + projectProfile);
-        }
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilderImpl.java
@@ -45,7 +45,8 @@ import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
 import org.kie.cloud.openshift.scenario.ScenarioRequest;
-import org.kie.cloud.openshift.template.ProjectProfile;
+
+import static org.kie.cloud.openshift.util.ScenarioValidations.verifyJbpmScenarioOnly;
 
 public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenario>
                                                                                              implements WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilder {
@@ -54,7 +55,7 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenari
     private ScenarioRequest request = new ScenarioRequest();
 
     public WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenarioBuilderImpl() {
-        isScenarioAllowed();
+        verifyJbpmScenarioOnly();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
         authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
@@ -226,18 +227,6 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerAmqWithDatabaseScenari
         }
 
         return this;
-    }
-
-    private static void isScenarioAllowed() {
-        ProjectProfile projectProfile = ProjectProfile.fromSystemProperty();
-        switch (projectProfile) {
-            case JBPM:
-                return;
-            case DROOLS:
-                throw new UnsupportedOperationException("Not supported");
-            default:
-                throw new IllegalStateException("Unrecognized ProjectProfile: " + projectProfile);
-        }
     }
 
     @Override

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/scenario/builder/WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl.java
@@ -45,7 +45,8 @@ import org.kie.cloud.openshift.operator.model.components.SsoClient;
 import org.kie.cloud.openshift.operator.scenario.WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioImpl;
 import org.kie.cloud.openshift.operator.settings.LdapSettingsMapper;
 import org.kie.cloud.openshift.scenario.ScenarioRequest;
-import org.kie.cloud.openshift.template.ProjectProfile;
+
+import static org.kie.cloud.openshift.util.ScenarioValidations.verifyJbpmScenarioOnly;
 
 public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl extends AbstractOpenshiftScenarioBuilderOperator<WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenario> implements
                                                                                           WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilder {
@@ -54,7 +55,7 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBu
     private ScenarioRequest request = new ScenarioRequest();
 
     public WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBuilderImpl() {
-        isScenarioAllowed();
+        verifyJbpmScenarioOnly();
 
         List<Env> authenticationEnvVars = new ArrayList<>();
         authenticationEnvVars.add(new Env(ImageEnvVariables.KIE_ADMIN_USER, DeploymentConstants.getAppUser()));
@@ -215,18 +216,6 @@ public class WorkbenchRuntimeSmartRouterImmutableKieServerWithDatabaseScenarioBu
         }
 
         return this;
-    }
-
-    private static void isScenarioAllowed() {
-        ProjectProfile projectProfile = ProjectProfile.fromSystemProperty();
-        switch (projectProfile) {
-            case JBPM:
-                return;
-            case DROOLS:
-                throw new UnsupportedOperationException("Not supported");
-            default:
-                throw new IllegalStateException("Unrecognized ProjectProfile: " + projectProfile);
-        }
     }
 
     @Override

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithMySqlScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithMySqlScenarioBuilderImpl.java
@@ -27,12 +27,16 @@ import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
 import org.kie.cloud.openshift.scenario.KieServerWithMySqlScenarioImpl;
 
+import static org.kie.cloud.openshift.util.ScenarioValidations.verifyJbpmScenarioOnly;
+
 public class KieServerWithMySqlScenarioBuilderImpl extends KieScenarioBuilderImpl<KieServerWithDatabaseScenarioBuilder, KieServerWithDatabaseScenario> implements KieServerWithDatabaseScenarioBuilder {
 
     private final Map<String, String> envVariables = new HashMap<>();
     private boolean deploySso = false;
 
     public KieServerWithMySqlScenarioBuilderImpl() {
+        verifyJbpmScenarioOnly();
+
         envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithPostgreSqlScenarioBuilderImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/builder/KieServerWithPostgreSqlScenarioBuilderImpl.java
@@ -27,12 +27,16 @@ import org.kie.cloud.openshift.constants.OpenShiftTemplateConstants;
 import org.kie.cloud.openshift.deployment.external.ExternalDeployment.ExternalDeploymentID;
 import org.kie.cloud.openshift.scenario.KieServerWithPostgreSqlScenarioImpl;
 
+import static org.kie.cloud.openshift.util.ScenarioValidations.verifyJbpmScenarioOnly;
+
 public class KieServerWithPostgreSqlScenarioBuilderImpl extends KieScenarioBuilderImpl<KieServerWithDatabaseScenarioBuilder, KieServerWithDatabaseScenario> implements KieServerWithDatabaseScenarioBuilder {
 
     private final Map<String, String> envVariables = new HashMap<>();
     private boolean deploySso = false;
 
     public KieServerWithPostgreSqlScenarioBuilderImpl() {
+        verifyJbpmScenarioOnly();
+
         envVariables.put(OpenShiftTemplateConstants.CREDENTIALS_SECRET, DeploymentConstants.getAppCredentialsSecretName());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_HTTPS_SECRET, OpenShiftConstants.getKieApplicationSecretName());
 

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/ScenarioValidations.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/ScenarioValidations.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.util;
+
+import org.kie.cloud.openshift.template.ProjectProfile;
+
+/**
+ * Utils to validate scenarios.
+ */
+public final class ScenarioValidations {
+
+    private ScenarioValidations() {
+
+    }
+
+    /**
+     * Verify that the template project for the execution is set to "jbpm". If not, it will raise:
+     * - An UnsupportedOperationException exception if it sets to "drools".
+     * - Otherwise, an IllegalStateException exception.
+     */
+    public static void verifyJbpmScenarioOnly() {
+        ProjectProfile projectProfile = ProjectProfile.fromSystemProperty();
+        switch (projectProfile) {
+            case JBPM:
+                return;
+            case DROOLS:
+                throw new UnsupportedOperationException("Not supported");
+            default:
+                throw new IllegalStateException("Unrecognized ProjectProfile: " + projectProfile);
+        }
+    }
+
+    /**
+     * Verify that the template project for the execution is set to "drools". If not, it will raise:
+     * - An UnsupportedOperationException exception if it sets to "jbpm".
+     * - Otherwise, an IllegalStateException exception.
+     */
+    public static void verifyDroolsScenarioOnly() {
+        ProjectProfile projectProfile = ProjectProfile.fromSystemProperty();
+        switch (projectProfile) {
+            case JBPM:
+                throw new UnsupportedOperationException("Not supported");
+            case DROOLS:
+                return;
+            default:
+                throw new IllegalStateException("Unrecognized ProjectProfile: " + projectProfile);
+        }
+    }
+}

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithMySqlLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithMySqlLdapIntegrationTest.java
@@ -85,7 +85,6 @@ public class KieServerWithMySqlLdapIntegrationTest extends AbstractCloudIntegrat
     }
 
     @Test
-    @Category(JBPMOnly.class)
     public void testProcessFromMavenRepo() {
         processTestProvider.testDeployFromKieServerAndExecuteProcesses(deploymentScenario.getKieServerDeployment());
     }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithMySqlLdapIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/ldap/KieServerWithMySqlLdapIntegrationTest.java
@@ -31,6 +31,7 @@ import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.tests.common.client.util.LdapSettingsConstants;
 
+@Category(JBPMOnly.class)
 public class KieServerWithMySqlLdapIntegrationTest extends AbstractCloudIntegrationTest {
 
     private static KieServerWithDatabaseScenario deploymentScenario;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenario;
@@ -37,13 +38,17 @@ import org.kie.cloud.tests.common.AutoScalerDeployment;
 import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.client.util.WorkbenchUtils;
+import org.kie.cloud.utils.TestRunnerFeature;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.controller.client.KieServerControllerClient;
 
-@Category(Smoke.class)
+@Category({Smoke.class, JBPMOnly.class})
 public class ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest extends AbstractCloudIntegrationTest {
+
+    @ClassRule
+    public static final TestRunnerFeature runner = new TestRunnerFeature("custom");
 
     private static ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenario deploymentScenario;
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
@@ -107,7 +107,6 @@ public class ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrat
     }
 
     @Test
-    @Category(JBPMOnly.class)
     public void testProcessFromMavenRepo() {
         processTestProvider.testExecuteProcesses(deploymentScenario.getKieServerDeployment(), DEFINITION_PROJECT_CONTAINER_ID);
     }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.cloud.api.scenario.ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenario;
@@ -38,7 +37,6 @@ import org.kie.cloud.tests.common.AutoScalerDeployment;
 import org.kie.cloud.tests.common.ScenarioDeployer;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.client.util.WorkbenchUtils;
-import org.kie.cloud.utils.TestRunnerFeature;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.client.KieServicesClient;
@@ -46,9 +44,6 @@ import org.kie.server.controller.client.KieServerControllerClient;
 
 @Category({Smoke.class, JBPMOnly.class})
 public class ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenarioIntegrationTest extends AbstractCloudIntegrationTest {
-
-    @ClassRule
-    public static final TestRunnerFeature runner = new TestRunnerFeature("custom");
 
     private static ClusteredWorkbenchRuntimeClusteredKieServerDatabaseScenario deploymentScenario;
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
@@ -37,6 +37,7 @@ import org.kie.cloud.api.scenario.KieServerScenario;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
 import org.kie.cloud.api.scenario.KjarDeploymentScenarioListener;
 import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
@@ -51,7 +52,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Category(Smoke.class)
+@Category({Smoke.class, JBPMOnly.class})
 @RunWith(Parameterized.class)
 public class KieServerWithBuiltKjarIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario<?>> {
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithBuiltKjarIntegrationTest.java
@@ -37,7 +37,6 @@ import org.kie.cloud.api.scenario.KieServerScenario;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
 import org.kie.cloud.api.scenario.KjarDeploymentScenarioListener;
 import org.kie.cloud.common.provider.KieServerClientProvider;
-import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.integrationtests.category.Smoke;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
@@ -52,7 +51,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Category({Smoke.class, JBPMOnly.class})
+@Category(Smoke.class)
 @RunWith(Parameterized.class)
 public class KieServerWithBuiltKjarIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieDeploymentScenario<?>> {
 

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithMySqlScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithMySqlScenarioIntegrationTest.java
@@ -30,7 +30,7 @@ import org.kie.cloud.integrationtests.testproviders.ProcessTestProvider;
 import org.kie.cloud.tests.common.AbstractCloudIntegrationTest;
 import org.kie.cloud.tests.common.ScenarioDeployer;
 
-@Category(Smoke.class)
+@Category({Smoke.class, JBPMOnly.class})
 public class KieServerWithMySqlScenarioIntegrationTest extends AbstractCloudIntegrationTest {
 
     private static KieServerWithDatabaseScenario deploymentScenario;

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithMySqlScenarioIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/smoke/KieServerWithMySqlScenarioIntegrationTest.java
@@ -70,7 +70,6 @@ public class KieServerWithMySqlScenarioIntegrationTest extends AbstractCloudInte
     }
 
     @Test
-    @Category(JBPMOnly.class)
     public void testProcessFromMavenRepo() {
         processTestProvider.testDeployFromKieServerAndExecuteProcesses(deploymentScenario.getKieServerDeployment());
     }

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/DbSurvivalIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/survival/DbSurvivalIntegrationTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -33,6 +34,7 @@ import org.kie.cloud.api.DeploymentScenarioBuilderFactoryLoader;
 import org.kie.cloud.api.deployment.KjarDeployer;
 import org.kie.cloud.api.scenario.KieServerWithDatabaseScenario;
 import org.kie.cloud.common.provider.KieServerClientProvider;
+import org.kie.cloud.integrationtests.category.JBPMOnly;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.time.Constants;
@@ -48,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@Category(JBPMOnly.class)
 @RunWith(Parameterized.class)
 public class DbSurvivalIntegrationTest extends AbstractMethodIsolatedCloudIntegrationTest<KieServerWithDatabaseScenario> {
 


### PR DESCRIPTION
These tests do not support DROOLS, so in order to avoid setup the environment, we can quickly skip those when running in RHDM.