### PR TITLE
BAQE-1327: Fix WorkbenchPersistenceIntegrationTest tests in RHDM/RHPAM

### DIFF
--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -71,6 +71,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- XTF dependencies -->
     <dependency>

--- a/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/utils/AwaitilityUtils.java
+++ b/test-cloud/test-cloud-remote/src/main/java/org/kie/cloud/utils/AwaitilityUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.utils;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Awaitility utils to make a long or repeatable operation.
+ */
+public class AwaitilityUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(AwaitilityUtils.class);
+
+    private AwaitilityUtils() {
+
+    }
+
+    /**
+     * Wait until supplier returns a not null instance.
+     *
+     * @param supplier method to return the instance.
+     * @return the non null instance.
+     */
+    @SuppressWarnings("unchecked")
+    public static final <T> T untilIsNotNull(Supplier<T> supplier) {
+        return until(supplier, (Matcher<T>) Matchers.notNullValue());
+    }
+
+    /**
+     * Wait until supplier returns a not empty array.
+     *
+     * @param supplier method to return the instance.
+     * @return the non empty array.
+     */
+    public static final <T> T[] untilIsNotEmpty(Supplier<T[]> supplier) {
+        return until(supplier, Matchers.arrayWithSize(Matchers.greaterThan(0)));
+    }
+
+    /**
+     * Wait until the supplier returns an instance that satisfies the asserts.
+     *
+     * @param supplier method to return the instance.
+     * @param asserts custom assertions that the instance must satisfy.
+     */
+    public static final <T> void untilAsserted(Supplier<T> supplier, Consumer<T> asserts) {
+        awaits().untilAsserted(() -> asserts.accept(get(supplier).call()));
+    }
+
+    private static final <T> T until(Supplier<T> supplier, Matcher<T> matcher) {
+        return awaits().until(get(supplier), matcher);
+    }
+
+    private static final <T> Callable<T> get(Supplier<T> supplier) {
+        return () -> {
+            T instance = supplier.get();
+            logger.trace("Checking ... {}", instance);
+            return instance;
+        };
+    }
+
+    private static final ConditionFactory awaits() {
+        return Awaitility.await()
+                         .pollInterval(5, TimeUnit.SECONDS)
+                         .atMost(3, TimeUnit.MINUTES);
+    }
+}

--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/persistence/WorkbenchPersistenceIntegrationTest.java
@@ -44,6 +44,7 @@ import org.kie.cloud.integrationtests.category.OperatorNotSupported;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.client.util.WorkbenchUtils;
+import org.kie.cloud.utils.AwaitilityUtils;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieServerInfo;
@@ -51,7 +52,6 @@ import org.kie.server.api.model.KieServiceResponse.ResponseType;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
-import org.kie.server.controller.api.model.spec.ServerTemplateList;
 import org.kie.server.controller.client.KieServerControllerClient;
 import org.kie.wb.test.rest.client.WorkbenchClient;
 import org.slf4j.Logger;
@@ -166,16 +166,19 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
         assertThat(containersResponse.getResult().getContainers().get(0).getContainerId()).isEqualTo(CONTAINER_ID);
     }
 
-    private void verifyOneServerTemplateWithContainer(String containerId) {
-        ServerTemplateList serverTemplates = kieControllerClient.listServerTemplates();
-        assertThat(serverTemplates.getServerTemplates()).as("Number of server templates differ.").hasSize(1);
+    private void verifyOneServerTemplate() {
+        ServerTemplate[] serverTemplates = AwaitilityUtils.untilIsNotEmpty(() -> kieControllerClient.listServerTemplates().getServerTemplates());
+        assertThat(serverTemplates).as("Number of server templates differ.").hasSize(1);
+    }
 
-        ServerTemplate serverTemplate = serverTemplates.getServerTemplates()[0];
-        assertThat(serverTemplate.getServerInstanceKeys()).hasSize(1);
-        // Skip check on URL as the workbench has an internal IP to KIE server and we only have the route here
-        // assertThat(serverTemplate.getServerInstanceKeys().iterator().next().getUrl()).isEqualTo(kieServerLocation);
-        assertThat(serverTemplate.getContainersSpec()).hasSize(1);
-        assertThat(serverTemplate.getContainersSpec().iterator().next().getId()).isEqualTo(containerId);
+    private void verifyOneServerTemplateWithContainer(String containerId) {
+        AwaitilityUtils.untilAsserted(() -> kieControllerClient.listServerTemplates().getServerTemplates()[0], serverTemplate -> {
+            assertThat(serverTemplate.getServerInstanceKeys()).hasSize(1);
+            // Skip check on URL as the workbench has an internal IP to KIE server and we only have the route here
+            // assertThat(serverTemplate.getServerInstanceKeys().iterator().next().getUrl()).isEqualTo(kieServerLocation);
+            assertThat(serverTemplate.getContainersSpec()).hasSize(1);
+            assertThat(serverTemplate.getContainersSpec().iterator().next().getId()).isEqualTo(containerId);
+        });
     }
 
     private void assertSpaceAndProjectExists(String spaceName, String projectName) {
@@ -191,5 +194,7 @@ public class WorkbenchPersistenceIntegrationTest extends AbstractMethodIsolatedC
         deployment.waitForScale();
         deployment.scale(1);
         deployment.waitForScale();
+
+        verifyOneServerTemplate();
     }
 }


### PR DESCRIPTION
Actions:

- Wait until KIE Server is connected back to Business Central after Business Central restart
- Use Awaitility framework to check list of server instances
- The Awaitility framework is fully well integrated with JUnit and this version (3.0.0 a bit old) was already managed by kie-parent.

RHPAM Jenkins Job that confirms this test is now working fine: https://rhba-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/jcarvaja/job/RHPAM-7.7-verification-openshift-single/

For RHDM: https://rhba-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/jcarvaja/job/RHDM-7.7-verification-openshift-single/