### PR TITLE
BAQE-1386: Make persistent tests more resilient

### DIFF
--- a/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/PersistenceTestProvider.java
+++ b/test-cloud/test-cloud-remote/src/test/java/org/kie/cloud/integrationtests/testproviders/PersistenceTestProvider.java
@@ -24,11 +24,11 @@ import org.kie.cloud.common.provider.KieServerClientProvider;
 import org.kie.cloud.common.provider.KieServerControllerClientProvider;
 import org.kie.cloud.tests.common.client.util.Kjar;
 import org.kie.cloud.tests.common.client.util.WorkbenchUtils;
+import org.kie.cloud.utils.AwaitilityUtils;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
-import org.kie.server.controller.api.model.spec.ServerTemplateList;
 import org.kie.server.controller.client.KieServerControllerClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,12 +93,13 @@ public class PersistenceTestProvider {
     }
 
     private static void verifyOneServerTemplateWithContainer(KieServerControllerClient kieControllerClient, String kieServerId, String containerId) {
-        ServerTemplateList serverTemplates = kieControllerClient.listServerTemplates();
-        assertThat(serverTemplates.getServerTemplates()).as("Number of server templates differ.").hasSize(1);
+        AwaitilityUtils.untilAsserted(() -> kieControllerClient.listServerTemplates(), serverTemplates -> {
+            assertThat(serverTemplates.getServerTemplates()).as("Number of server templates differ.").hasSize(1);
 
-        ServerTemplate serverTemplate = serverTemplates.getServerTemplates()[0];
-        assertThat(serverTemplate.getServerInstanceKeys()).hasSize(1);
-        assertThat(serverTemplate.getId()).isEqualTo(kieServerId);
-        assertThat(serverTemplate.getContainersSpec()).anyMatch(containerSpec -> containerSpec.getId().equals(containerId));
+            ServerTemplate serverTemplate = serverTemplates.getServerTemplates()[0];
+            assertThat(serverTemplate.getServerInstanceKeys()).hasSize(1);
+            assertThat(serverTemplate.getId()).isEqualTo(kieServerId);
+            assertThat(serverTemplate.getContainersSpec()).anyMatch(containerSpec -> containerSpec.getId().equals(containerId));
+        });
     }
 }


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/BAQE-1386
Description: 
What this test PersistenceTestProvider is doing is basically:
1.- Deploy container into Kie Server
2.- Restart Workbench
3.- Verify Workbench is still connected to Kie Server with the expected containers

The problem is that when restarting the Workbench, it might take some time to reconnect with the Kie Servers.

Solution:
My change is about to make the step 3 to wait until the asserts are working fine. Another possibility would be to wait for the re connection between kie-server and workbench and then run the step 3. 