### PR TITLE
BAQE-1393: Update workarounds to the new issue and delete RHPAM-2830

### DIFF
--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchKieServerPersistentScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchKieServerPersistentScenarioImpl.java
@@ -97,8 +97,6 @@ public class ClusteredWorkbenchKieServerPersistentScenarioImpl extends KieCommon
         workbenchDeployment = new WorkbenchDeploymentImpl(project);
         workbenchDeployment.setUsername(DeploymentConstants.getAppUser());
         workbenchDeployment.setPassword(DeploymentConstants.getAppPassword());
-        // Workaround for RHPAM-2830
-        workbenchDeployment.scale(1);
 
         kieServerDeployment = new KieServerDeploymentImpl(project);
         kieServerDeployment.setUsername(DeploymentConstants.getAppUser());

--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioImpl.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/scenario/ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenarioImpl.java
@@ -86,10 +86,8 @@ public class ClusteredWorkbenchRuntimeSmartRouterTwoKieServersTwoDatabasesScenar
             envVariables.put(OpenShiftTemplateConstants.KIE_SERVER2_SSO_SECRET, "kie-server2-secret");
         }
 
-        // Workaround for RHPAM-2830
+        // Workaround for RHPAM-2919
         envVariables.put(OpenShiftTemplateConstants.BUSINESS_CENTRAL_MONITORING_CONTAINER_REPLICAS, "1");
-        // Workaround for BAQE-1358
-        envVariables.put(OpenShiftTemplateConstants.SMART_ROUTER_CONTAINER_REPLICAS, "1");
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_CONTAINER_REPLICAS, "1");
 
         logger.info("Processing template and creating resources from " + OpenShiftTemplate.CLUSTERED_CONSOLE_SMARTROUTER_TWO_KIE_SERVERS_TWO_DATABASES.getTemplateUrl().toString());


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/BAQE-1393
Update workarounds as RHPAM-2830 was resolved and the issue with the production template has been separated into RHPAM-2919