### PR TITLE
BAQE-1316: Increase RHSSO to 7.4.0 in kie-cloud-tests

### DIFF
--- a/framework-cloud/framework-openshift/pom.xml
+++ b/framework-cloud/framework-openshift/pom.xml
@@ -44,10 +44,6 @@
     <!-- RH SSO dependencies  -->
     <dependency>
       <groupId>org.keycloak</groupId>
-      <artifactId>keycloak-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.keycloak</groupId>
       <artifactId>keycloak-admin-client</artifactId>
     </dependency>
     <dependency>

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -33,9 +33,9 @@
     <template.project/> <!-- valid values: jbpm, drools-->
 
     <!-- Properties to configure SSO -->
-    <sso.image.streams>https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso73-dev/templates/sso73-image-stream.json</sso.image.streams>
+    <sso.image.streams>https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso74-dev/templates/sso74-image-stream.json</sso.image.streams>
     <sso.app.secrets>https://raw.githubusercontent.com/jboss-openshift/application-templates/master/secrets/sso-app-secret.json</sso.app.secrets>
-    <sso.app.template>https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso73-dev/templates/sso73-https.json</sso.app.template>
+    <sso.app.template>https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso74-dev/templates/sso74-https.json</sso.app.template>
     <sso.app.realm>demo</sso.app.realm>
     <sso.admin.username>admin</sso.admin.username>
     <sso.admin.password>admin</sso.admin.password>

--- a/test-cloud/test-cloud-remote/src/test/resources/test.properties
+++ b/test-cloud/test-cloud-remote/src/test/resources/test.properties
@@ -4,9 +4,9 @@ openshift.password=redhat
 openshift.admin.username=admin
 openshift.admin.password=admin
 
-sso.image.streams=https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso73-dev/templates/sso73-image-stream.json
+sso.image.streams=https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso74-dev/templates/sso74-image-stream.json
 sso.app.secrets=https://raw.githubusercontent.com/jboss-openshift/application-templates/master/secrets/sso-app-secret.json
-sso.app.template=https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso73-dev/templates/sso73-https.json
+sso.app.template=https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso74-dev/templates/sso74-https.json
 sso.app.realm=demo
 sso.admin.username=admin
 sso.admin.password=admin


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/BAQE-1316
Description: Use latest 7.4.0 for cloud tests

I've ran a few tests using the latest SSO and they worked as expected.
I didn't need to upgrade the Maven dependencies for keycloak.