### PR TITLE
BAQE-1421: Fix External Database tests that need download drivers

### DIFF
--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
@@ -16,8 +16,6 @@
 package org.kie.cloud.openshift.constants;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Optional;
 
 import cz.xtf.core.config.OpenShiftConfig;
@@ -167,11 +165,6 @@ public class OpenShiftConstants implements Constants {
      */
     public static final String KIE_JDBC_DRIVER_SCRIPTS = "kie.jdbc.driver.scripts";
 
-    /**
-     * URL pointing to JDBC driver binary.
-     */
-    public static final String KIE_JDBC_DRIVER_BINARY_URL = "kie.jdbc.driver.binary.url";
-
     public static String getOpenShiftUrl() {
         return System.getProperty(OPENSHIFT_URL);
     }
@@ -245,15 +238,6 @@ public class OpenShiftConstants implements Constants {
         }
 
         return kieJdbcDriverScriptsFolder;
-    }
-
-    public static URL getKieJdbcDriverBinaryUrl() {
-        String kieJdbcDriverBinaryUrl = System.getProperty(KIE_JDBC_DRIVER_BINARY_URL);
-        try {
-            return new URL(kieJdbcDriverBinaryUrl);
-        } catch (MalformedURLException e) {
-            throw new RuntimeException("Malformed URL of Kie server JDBC driver binary.", e);
-        }
     }
 
     /**

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/AbstractExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/AbstractExternalDriver.java
@@ -16,12 +16,13 @@
 package org.kie.cloud.openshift.database.driver;
 
 import java.net.URL;
+import java.util.Optional;
 
 public abstract class AbstractExternalDriver implements ExternalDriver {
 
     @Override
     public String getSourceDockerTag() {
-        return "kiegroup/" + getImageName() + ":" + getImageVersion();
+        return "quay.io/kiegroup/" + getImageName() + ":" + getImageVersion();
     }
 
     @Override
@@ -31,6 +32,11 @@ public abstract class AbstractExternalDriver implements ExternalDriver {
 
     @Override
     public String getCekitImageBuildCommand() {
-        return "make build " + getName();
+        return "make build " + getName() + " BUILD_ENGINE=docker";
+    }
+
+    @Override
+    public Optional<String> getJdbcDriverUrl() {
+        return Optional.empty();
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/ExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/ExternalDriver.java
@@ -15,8 +15,8 @@
 
 package org.kie.cloud.openshift.database.driver;
 
-import java.io.File;
 import java.net.URL;
+import java.util.Optional;
 
 /**
  * Represents driver used by external database. This driver needs to be incorporated into Kie server image.
@@ -54,4 +54,9 @@ public interface ExternalDriver {
      * @return Cekit command to build driver image.
      */
     String getCekitImageBuildCommand();
+
+    /**
+     * @return a custom JDBC driver URL to be downloaded and use in the cekit command.
+     */
+    Optional<String> getJdbcDriverUrl();
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/OracleExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/OracleExternalDriver.java
@@ -15,6 +15,10 @@
 
 package org.kie.cloud.openshift.database.driver;
 
+import java.util.Optional;
+
+import org.kie.cloud.openshift.resource.CloudProperties;
+
 public class OracleExternalDriver extends AbstractExternalDriver {
 
     @Override
@@ -24,11 +28,16 @@ public class OracleExternalDriver extends AbstractExternalDriver {
 
     @Override
     public String getImageName() {
-        return "oracle-driver-image";
+        return "jboss-kie-oracle-extension-openshift-image";
     }
 
     @Override
     public String getImageVersion() {
         return "12c";
+    }
+
+    @Override
+    public Optional<String> getJdbcDriverUrl() {
+        return Optional.ofNullable(CloudProperties.getInstance().getOracleJdbcDriverUrl());
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/SybaseExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/SybaseExternalDriver.java
@@ -15,6 +15,10 @@
 
 package org.kie.cloud.openshift.database.driver;
 
+import java.util.Optional;
+
+import org.kie.cloud.openshift.resource.CloudProperties;
+
 public class SybaseExternalDriver extends AbstractExternalDriver {
 
     @Override
@@ -24,11 +28,16 @@ public class SybaseExternalDriver extends AbstractExternalDriver {
 
     @Override
     public String getImageName() {
-        return "sybase-driver-image";
+        return "jboss-kie-sybase-extension-openshift-image";
     }
 
     @Override
     public String getImageVersion() {
         return "16.0";
+    }
+
+    @Override
+    public Optional<String> getJdbcDriverUrl() {
+        return Optional.ofNullable(CloudProperties.getInstance().getSybaseJdbcDriverUrl());
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/CloudProperties.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/CloudProperties.java
@@ -33,6 +33,10 @@ public final class CloudProperties {
     private static final String CLOUD_PROPERTIES_LOCATION = "cloud.properties.location";
     private static final String LDAP_DOCKER_IMAGE_PROPERTY = "ldap.docker.image";
     private static final String GOGS_DOCKER_IMAGE_PROPERTY = "gogs.docker.image";
+    
+    private static final String ORACLE_JDBC_DRIVER_URL = "oracle.jdbc.driver.url";
+    private static final String DB2_JDBC_DRIVER_URL = "db2.jdbc.driver.url";
+    private static final String SYBASE_JDBC_DRIVER_URL = "sybase.jdbc.driver.url";
 
     private static CloudProperties INSTANCE;
 
@@ -54,6 +58,18 @@ public final class CloudProperties {
 
     public String getGogsDockerImage() {
         return getProperty(GOGS_DOCKER_IMAGE_PROPERTY);
+    }
+    
+    public String getOracleJdbcDriverUrl() {
+        return getProperty(ORACLE_JDBC_DRIVER_URL);
+    }
+    
+    public String getSybaseJdbcDriverUrl() {
+        return getProperty(SYBASE_JDBC_DRIVER_URL);
+    }
+    
+    public String getDb2JdbcDriverUrl() {
+        return getProperty(DB2_JDBC_DRIVER_URL);
     }
 
     private String getProperty(String key) {

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/CustomDatabaseImageBuilder.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/CustomDatabaseImageBuilder.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.cloud.openshift.util;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+
+import org.apache.commons.io.FilenameUtils;
+import org.kie.cloud.api.deployment.DockerDeployment;
+import org.kie.cloud.openshift.constants.OpenShiftConstants;
+import org.kie.cloud.openshift.database.driver.ExternalDriver;
+import org.kie.cloud.openshift.resource.Project;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Use cekit to create a custom database image.
+ */
+public class CustomDatabaseImageBuilder {
+
+    private static final Logger logger = LoggerFactory.getLogger(CustomDatabaseImageBuilder.class);
+
+    private CustomDatabaseImageBuilder() {
+
+    }
+
+    /**
+     * Create image stream from external image with driver and reference it for custom resource.
+     * @param project where to create the image stream.
+     * @param dockerDeployment registry to use.
+     * @param externalDriver database driver to use.
+     * @return the created image tag.
+     */
+    public static final String build(Project project, DockerDeployment dockerDeployment, ExternalDriver externalDriver) {
+        downloadJdbcDriver(externalDriver);
+        installDriverImageToRegistry(dockerDeployment, externalDriver);
+        createDriverImageStreams(project, dockerDeployment, externalDriver);
+        return externalDriver.getImageName() + ":" + externalDriver.getImageVersion();
+    }
+
+    private static void downloadJdbcDriver(ExternalDriver externalDriver) {
+        externalDriver.getJdbcDriverUrl().ifPresent(jdbcDriverUrl -> {
+            File jdbcDriverFile = getJdbcDriverFile(jdbcDriverUrl);
+            if (jdbcDriverFile.exists()) {
+                return;
+            }
+
+            logger.info("Downloading JDBC driver from {} to {}", jdbcDriverUrl, jdbcDriverFile.getAbsolutePath());
+            try (ReadableByteChannel rbc = Channels.newChannel(new URL(jdbcDriverUrl).openStream());
+                    FileOutputStream fos = new FileOutputStream(jdbcDriverFile)) {
+                fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            } catch (IOException e) {
+                throw new RuntimeException("Error while downloading driver binary.", e);
+            }
+        });
+
+    }
+
+    private static File getJdbcDriverFile(String jdbcDriverUrl) {
+        String filename = FilenameUtils.getName(jdbcDriverUrl);
+        return new File(OpenShiftConstants.getKieJdbcDriverScriptsFolder(), filename);
+    }
+
+    private static String getCekitCommand(ExternalDriver externalDriver) {
+        String buildCommand = externalDriver.getCekitImageBuildCommand();
+        if (externalDriver.getJdbcDriverUrl().isPresent()) {
+            String artifact = getJdbcDriverFile(externalDriver.getJdbcDriverUrl().get()).getAbsolutePath();
+            String version = externalDriver.getImageVersion();
+            buildCommand += String.format(" artifact=%s version=%s", artifact, version);
+        }
+
+        return buildCommand;
+    }
+
+    private static void installDriverImageToRegistry(DockerDeployment dockerDeployment, ExternalDriver externalDriver) {
+        File kieJdbcDriverScriptsFolder = OpenShiftConstants.getKieJdbcDriverScriptsFolder();
+        String buildCommand = getCekitCommand(externalDriver);
+        String sourceDockerTag = externalDriver.getSourceDockerTag();
+        String targetDockerTag = externalDriver.getTargetDockerTag(dockerDeployment.getUrl());
+
+        try (ProcessExecutor processExecutor = new ProcessExecutor()) {
+            logger.info("Building JDBC driver image");
+            processExecutor.executeProcessCommand(buildCommand, kieJdbcDriverScriptsFolder.toPath());
+
+            logger.info("Pushing JDBC driver image to Docker registry.");
+            processExecutor.executeProcessCommand("docker tag " + sourceDockerTag + " " + targetDockerTag);
+            processExecutor.executeProcessCommand("docker push " + targetDockerTag);
+        }
+    }
+
+    private static void createDriverImageStreams(Project project, DockerDeployment dockerDeployment, ExternalDriver externalDriver) {
+        String imageStreamName = externalDriver.getImageName();
+        String dockerTag = externalDriver.getTargetDockerTag(dockerDeployment.getUrl());
+
+        project.createImageStreamFromInsecureRegistry(imageStreamName, dockerTag);
+    }
+}

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/DockerRegistryDeployer.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/util/DockerRegistryDeployer.java
@@ -15,8 +15,6 @@
  */
 package org.kie.cloud.openshift.util;
 
-import java.io.IOException;
-
 import cz.xtf.core.openshift.OpenShiftBinary;
 import cz.xtf.core.openshift.OpenShifts;
 import org.kie.cloud.api.deployment.DockerDeployment;

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -324,7 +324,6 @@ $ keytool -import -trustcacerts -alias name -keypass pass -storepass pass -keyst
               <db.jdbc_url>${db.jdbc_url}</db.jdbc_url>
               <hibernate.dialect>${hibernate.dialect}</hibernate.dialect>
               <db.driver>${db.driver}</db.driver>
-              <kie.jdbc.driver.binary.url>${kie.jdbc.driver.binary.url}</kie.jdbc.driver.binary.url>
               <kie.jdbc.driver.scripts>${kie.jdbc.driver.scripts}</kie.jdbc.driver.scripts>
               <kie.app.name>${kie.app.name}</kie.app.name>
               <git.provider>${git.provider}</git.provider>


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/BAQE-1421
Description:
- Add new BUILD_ENGINE to the cekit command (by default, it uses podman and the jenkins node does not have it installed)
- Change the image name (it didn't match with the one in the templates.zip...)
- Fixed the repository (see more about this issue in https://issues.redhat.com/browse/RHPAM-2948)
- Removed unused "kie.jdbc.driver.binary.url" parameter
- Download driver only for propietary databases (oracle and sybase)