### PR TITLE
BAQE-1421 Fix sybase driver and revert BUILD_ENGINE param

### DIFF
--- a/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/SybaseExternalDatabase.java
+++ b/framework-cloud/framework-openshift-templates/src/main/java/org/kie/cloud/openshift/database/external/SybaseExternalDatabase.java
@@ -33,6 +33,7 @@ public class SybaseExternalDatabase extends AbstractSybaseExternalDatabase imple
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_EXTERNALDB_USER, DeploymentConstants.getDatabaseUsername());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_EXTERNALDB_PWD, DeploymentConstants.getDatabasePassword());
         envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_EXTERNALDB_DIALECT, DeploymentConstants.getHibernatePersistenceDialect());
+        envVariables.put(OpenShiftTemplateConstants.KIE_SERVER_EXTERNALDB_URL, DeploymentConstants.getDatabaseUrl());
         return envVariables;
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/AbstractExternalDriver.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/database/driver/AbstractExternalDriver.java
@@ -22,7 +22,7 @@ public abstract class AbstractExternalDriver implements ExternalDriver {
 
     @Override
     public String getSourceDockerTag() {
-        return "quay.io/kiegroup/" + getImageName() + ":" + getImageVersion();
+        return "kiegroup/" + getImageName() + ":" + getImageVersion();
     }
 
     @Override
@@ -32,7 +32,7 @@ public abstract class AbstractExternalDriver implements ExternalDriver {
 
     @Override
     public String getCekitImageBuildCommand() {
-        return "make build " + getName() + " BUILD_ENGINE=docker";
+        return "make build " + getName();
     }
 
     @Override


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/BAQE-1421
Description: 
- Sybase needs the KIE_SERVER_EXTERNALDB_URL property to be set (the default jdbc url is not working)
- The BUILD_ENGINE parameter was changed to Docker as part of RHPAM-2948