### PR TITLE
BAQE-1467: Fix Upgrade Operator tests

### DIFF
--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/SmartRouterOperatorDeployment.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/SmartRouterOperatorDeployment.java
@@ -15,6 +15,8 @@
 
 package org.kie.cloud.openshift.operator.deployment;
 
+import java.util.Optional;
+
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -49,11 +51,10 @@ public class SmartRouterOperatorDeployment extends SmartRouterDeploymentImpl {
     public void waitForScale() {
         KieApp kieApp = kieAppClient.withName(OpenShiftConstants.getKieApplicationName()).get();
 
-        Integer replicas = kieApp.getStatus().getApplied().getObjects().getSmartRouter().getReplicas();
-        if (replicas == null) {
-            // If replicas are not set in custom resource then get them from deployment config.
-            replicas = getOpenShift().getDeploymentConfig(getServiceName()).getSpec().getReplicas();
-        }
+        Integer replicas = Optional.ofNullable(kieApp.getStatus())
+                                   .map(status -> status.getApplied())
+                                   .map(applied -> applied.getObjects().getSmartRouter().getReplicas())
+                                   .orElseGet(() -> getOpenShift().getDeploymentConfig(getServiceName()).getSpec().getReplicas());
 
         waitUntilAllPodsAreReadyAndRunning(replicas);
         if (replicas > 0) {

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/WorkbenchOperatorDeployment.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/deployment/WorkbenchOperatorDeployment.java
@@ -15,6 +15,8 @@
 
 package org.kie.cloud.openshift.operator.deployment;
 
+import java.util.Optional;
+
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import org.kie.cloud.openshift.constants.OpenShiftConstants;
@@ -49,11 +51,10 @@ public class WorkbenchOperatorDeployment extends WorkbenchDeploymentImpl {
     public void waitForScale() {
         KieApp kieApp = kieAppClient.withName(OpenShiftConstants.getKieApplicationName()).get();
 
-        Integer replicas = kieApp.getStatus().getApplied().getObjects().getConsole().getReplicas();
-        if (replicas == null) {
-            // If replicas are not set in custom resource then get them from deployment config.
-            replicas = getOpenShift().getDeploymentConfig(getServiceName()).getSpec().getReplicas();
-        }
+        Integer replicas = Optional.ofNullable(kieApp.getStatus())
+                                   .map(status -> status.getApplied())
+                                   .map(applied -> applied.getObjects().getConsole().getReplicas())
+                                   .orElseGet(() -> getOpenShift().getDeploymentConfig(getServiceName()).getSpec().getReplicas());
 
         waitUntilAllPodsAreReadyAndRunning(replicas);
         if (replicas > 0) {


### PR DESCRIPTION
 JIRA: https://issues.redhat.com/browse/BAQE-1467
Description:
Fix upgrade tests by:
- Checking whether the "applied" field exists to get the replicas number
- Checking the image reference via the provided sha256