### PR TITLE
BAQE-1470: Fix External Database tests using Operator (#651)

### DIFF
--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/Db2ExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/Db2ExternalDatabase.java
@@ -17,4 +17,9 @@ package org.kie.cloud.openshift.operator.database.external;
 import org.kie.cloud.openshift.database.external.AbstractDb2ExternalDatabase;
 
 public class Db2ExternalDatabase extends AbstractDb2ExternalDatabase implements OperatorExternalDatabase {
+
+    @Override
+    public boolean needsToSetExternalUrl() {
+        return false;
+    }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/OperatorExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/OperatorExternalDatabase.java
@@ -29,15 +29,27 @@ public interface OperatorExternalDatabase extends ExternalDatabase {
         database.setType("external");
 
         ExternalConfig config = new ExternalConfig();
+        if (needsToSetExternalUrl()) {
+            config.setJdbcURL(DeploymentConstants.getDatabaseUrl());
+        } else {
+            config.setHost(DeploymentConstants.getDatabaseHost());
+            config.setPort(DeploymentConstants.getDatabasePort());
+        }
+
         config.setDriver(getExternalDriver().getName());
         config.setDialect(Optional.ofNullable(getHibernateDialect()).orElse(DeploymentConstants.getHibernatePersistenceDialect()));
-        config.setHost(DeploymentConstants.getDatabaseHost());
-        config.setPort(DeploymentConstants.getDatabasePort());
         config.setUsername(DeploymentConstants.getDatabaseUsername());
         config.setPassword(DeploymentConstants.getDatabasePassword());
         config.setName(DeploymentConstants.getExternalDatabaseName());
         database.setExternalConfig(config);
 
         return database;
+    }
+
+    /**
+     * @return Flag to indicate that the jdbcURL field needs to be populated (default true).
+     */
+    default boolean needsToSetExternalUrl() {
+        return true;
     }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/PostgreSqlExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/PostgreSqlExternalDatabase.java
@@ -17,4 +17,9 @@ package org.kie.cloud.openshift.operator.database.external;
 import org.kie.cloud.openshift.database.external.AbstractPostgreSqlExternalDatabase;
 
 public class PostgreSqlExternalDatabase extends AbstractPostgreSqlExternalDatabase implements OperatorExternalDatabase {
+
+    @Override
+    public boolean needsToSetExternalUrl() {
+        return false;
+    }
 }

--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/PostgreSqlPlusExternalDatabase.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/database/external/PostgreSqlPlusExternalDatabase.java
@@ -17,4 +17,9 @@ package org.kie.cloud.openshift.operator.database.external;
 import org.kie.cloud.openshift.database.external.AbstractPostgreSqlPlusExternalDatabase;
 
 public class PostgreSqlPlusExternalDatabase extends AbstractPostgreSqlPlusExternalDatabase implements OperatorExternalDatabase {
+
+    @Override
+    public boolean needsToSetExternalUrl() {
+        return false;
+    }
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/BAQE-1470
Description: Use JDBC URL instead of HOST for external databases.