### PR TITLE
BAQE-1473: Fix DbSurvivalIntegrationTest random failures in Operator

### DIFF
--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/Deployment.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/Deployment.java
@@ -70,7 +70,7 @@ public interface Deployment {
     List<Instance> getInstances();
 
     /**
-     * This method delete given list of the cloud instances. Cloud should
+     * This method delete all instances for Deployment. Cloud should
      * automaticly start new instances. Number of available instance is same as
      * before.
      */

--- a/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/Deployment.java
+++ b/framework-cloud/framework-cloud-api/src/main/java/org/kie/cloud/api/deployment/Deployment.java
@@ -70,21 +70,11 @@ public interface Deployment {
     List<Instance> getInstances();
 
     /**
-     * This method delete given cloud instances. Cloud should automaticly start
-     * new instances. Number of available instance is same as before.
-     *
-     * @param instance Instances to be deleted
-     */
-    void deleteInstances(Instance... instance);
-
-    /**
      * This method delete given list of the cloud instances. Cloud should
      * automaticly start new instances. Number of available instance is same as
      * before.
-     *
-     * @param instances List of instances to be deleted
      */
-    void deleteInstances(List<Instance> instances);
+    void deleteInstances();
 
     /**
      * @return True if deployment is deployed and ready to be used.

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/OpenShiftDeployment.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/deployment/OpenShiftDeployment.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -83,16 +82,8 @@ public abstract class OpenShiftDeployment implements Deployment {
     }
 
     @Override
-    public void deleteInstances(Instance... instance) {
-        deleteInstances(Arrays.asList(instance));
-    }
-
-    @Override
-    public void deleteInstances(List<Instance> instances) {
-        for (Instance instance : instances) {
-            Pod pod = openShift.getPod(instance.getName());
-            openShift.deletePod(pod);
-        }
+    public void deleteInstances() {
+        getInstances().forEach(this::deleteInstance);
     }
 
     public abstract String getServiceName();
@@ -352,6 +343,11 @@ public abstract class OpenShiftDeployment implements Deployment {
         }
 
         return StringUtils.endsWith(image, versionTag);
+    }
+
+    private void deleteInstance(Instance instance) {
+        Pod pod = openShift.getPod(instance.getName());
+        openShift.deletePod(pod);
     }
 
     private Map<String, Quantity> transformMap(Map<String, String> x) {

--- a/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPKjarUpdateIntegrationTest.java
+++ b/test-cloud/test-cloud-ha-cep/src/test/java/org/kie/cloud/hacep/HACEPKjarUpdateIntegrationTest.java
@@ -15,8 +15,6 @@
 
 package org.kie.cloud.hacep;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -25,7 +23,6 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import org.apache.commons.math3.stat.inference.TestUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.kie.cloud.api.DeploymentScenarioBuilderFactory;
@@ -35,9 +32,10 @@ import org.kie.cloud.openshift.resource.Project;
 import org.kie.cloud.openshift.resource.impl.ProjectImpl;
 import org.kie.cloud.tests.common.AbstractMethodIsolatedCloudIntegrationTest;
 import org.kie.hacep.core.InfraFactory;
-import org.kie.remote.*;
+import org.kie.remote.RemoteFactHandle;
+import org.kie.remote.RemoteKieSession;
+import org.kie.remote.TopicsConfig;
 import org.kie.remote.impl.RemoteKieSessionImpl;
-import org.kie.remote.impl.RemoteStreamingKieSessionImpl;
 import org.kie.remote.impl.producer.Producer;
 import org.kie.remote.util.KafkaRemoteUtil;
 
@@ -185,8 +183,7 @@ public class HACEPKjarUpdateIntegrationTest extends AbstractMethodIsolatedCloudI
             final boolean updateKjarResult = updateKjarFuture.get();
             Assertions.assertThat(updateKjarResult).isTrue();
 
-            deploymentScenario.getDeployments().get(0)
-                    .deleteInstances(deploymentScenario.getDeployments().get(0).getInstances());
+            deploymentScenario.getDeployments().get(0).deleteInstances();
             deploymentScenario.getDeployments().get(0).waitForScale();
 
             final RemoteFactHandle<Map<String, String>> factHandle = producer.insert(new HashMap<>());


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/BAQE-1473
The old solution worked ok in Template, because we're using the DeploymentConfig to set the replicas but in Operator, when we set the replicas to 0, the operator automatically scales it out to 1 and this is the right behaviour.

This solution is to avoid scale up/down database and delete the pods to simulate failover scenarios. 