### PR TITLE
BAQE-1519: Fail fast when OC command is not installed

### DIFF
--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/constants/OpenShiftConstants.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.Optional;
 
 import cz.xtf.core.config.OpenShiftConfig;
+import cz.xtf.core.openshift.OpenShifts;
 import org.kie.cloud.api.constants.Constants;
 
 public class OpenShiftConstants implements Constants {
@@ -264,5 +265,9 @@ public class OpenShiftConstants implements Constants {
         System.setProperty(OpenShiftConfig.OPENSHIFT_ADMIN_PASSWORD, getOpenShiftAdminPassword() != null ? getOpenShiftAdminPassword() : getOpenShiftPassword());
         System.setProperty(OpenShiftConfig.OPENSHIFT_VERSION, getOpenShiftVersion());
         System.setProperty(OpenShiftConfig.OPENSHIFT_NAMESPACE, "openshift");
+
+        if (OpenShifts.adminBinary() == null) {
+            throw new RuntimeException("Oc client is not installed");
+        }
     }
 }

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/log/EventsRecorder.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/log/EventsRecorder.java
@@ -26,6 +26,10 @@ import org.kie.cloud.openshift.resource.Project;
 public class EventsRecorder {
 
     public static void recordProjectEvents(Project project, String logFolderName) {
+        if (project == null) {
+            return;
+        }
+
         StringBuffer writer = new StringBuffer();
         writer.append("LAST SEEN");
         writer.append('\t');

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/Project.java
@@ -65,25 +65,6 @@ public interface Project extends AutoCloseable {
      */
     void createSecret(String secretName, Map<String, String> secrets);
 
-
-    /**
-     * Create resources from YAML file using command line client.
-     * @param yamlUrl Url to yaml file with resources
-     */
-    public void createResourcesFromYaml(String yamlUrl);
-
-    /**
-     * Create resources from YAML files using command line client.
-     * @param yamlUrls Urls to yaml files with resources
-     */
-    public void createResourcesFromYaml(List<String> yamlUrls);
-
-    /**
-     * Create resources from YAML string using command line client.
-     * @param yamlString String with yaml
-     */
-    public void createResourceFromYamlString(String yamlString);
-
     /**
      * Create resources from YAML files as admin using command line client.
      * @param yamlUrl Url to yaml files with resources

--- a/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
+++ b/framework-cloud/framework-openshift/src/main/java/org/kie/cloud/openshift/resource/impl/ProjectImpl.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -142,33 +141,6 @@ public class ProjectImpl implements Project {
     }
 
     @Override
-    public void createResourcesFromYaml(String yamlUrl) {
-        final String output = openShiftBinaryClient().execute("create", "-f", yamlUrl);
-        logger.info("Yaml resources from file {} were created by oc client. Output = {}", yamlUrl, output);
-    }
-
-    @Override
-    public void createResourcesFromYaml(List<String> yamlUrls) {
-        final OpenShiftBinary oc = openShiftBinaryClient();
-        for (String url : yamlUrls) {
-            final String output = oc.execute("create", "-f", url);
-            logger.info("Yaml resources from file {} were created by oc client. Output = {}", url, output);
-        }
-    }
-
-    @Override
-    public void createResourceFromYamlString(String yamlString) {
-        try {
-            final File tmpYamlFile = File.createTempFile("openshift-resource-",".yaml");
-            Files.write(tmpYamlFile.toPath(), yamlString.getBytes("UTF-8"));
-            final String output = openShiftBinaryClient().execute("create", "-f", tmpYamlFile.getAbsolutePath());
-            logger.info("Yaml resources from string was created by oc client. Output = {}", output);
-        } catch (IOException e) {
-            throw new RuntimeException("Error creating resource from string", e);
-        }
-    }
-
-    @Override
     public void createResourcesFromYamlAsAdmin(String yamlUrl) {
         final String output = openShiftBinaryClientAsAdmin().execute("create", "-f", yamlUrl);
         logger.info("Yaml resources from file {} were created by oc client. Output = {}", yamlUrl, output);
@@ -195,25 +167,18 @@ public class ProjectImpl implements Project {
         }
     }
 
-    private OpenShiftBinary openShiftBinaryClient() {
-        Optional<OpenShiftBinary> oc;
-        synchronized (ProjectImpl.class) {
-            oc = Optional.of(OpenShifts.masterBinary(this.getName()));
-            oc.get().login(OpenShiftConstants.getOpenShiftUrl(), OpenShiftConstants.getOpenShiftUserName(),
-                           OpenShiftConstants.getOpenShiftPassword());
-        }
-        return oc.orElseThrow(RuntimeException::new);
+    private synchronized OpenShiftBinary openShiftBinaryClient() {
+        OpenShiftBinary oc = OpenShifts.masterBinary(this.getName());
+        oc.login(OpenShiftConstants.getOpenShiftUrl(), OpenShiftConstants.getOpenShiftUserName(),
+                 OpenShiftConstants.getOpenShiftPassword());
+        return oc;
     }
 
-    private OpenShiftBinary openShiftBinaryClientAsAdmin() {
-        Optional<OpenShiftBinary> oc;
-        synchronized (ProjectImpl.class) {
-            oc = Optional.of(OpenShifts.masterBinary(this.getName()));
-            oc.get().login(OpenShiftConstants.getOpenShiftUrl(), OpenShiftConstants.getOpenShiftAdminUserName(),
-                           OpenShiftConstants.getOpenShiftAdminPassword());
-        }
-
-        return oc.orElseThrow(RuntimeException::new);
+    private synchronized OpenShiftBinary openShiftBinaryClientAsAdmin() {
+        OpenShiftBinary oc = OpenShifts.masterBinary(this.getName());
+        oc.login(OpenShiftConstants.getOpenShiftUrl(), OpenShiftConstants.getOpenShiftAdminUserName(),
+                 OpenShiftConstants.getOpenShiftAdminPassword());
+        return oc;
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/BAQE-1519
Some tests return that some X service is not installed. The root cause is that the OC client was not installed. These changes are to make the tests fail fast when this happened.