### PR TITLE
Use Operator branch with fix deploy yaml naming

### DIFF
--- a/framework-cloud/framework-openshift-operator/src/main/resources/org/kie/cloud/openshift/operator/resources/resources.properties
+++ b/framework-cloud/framework-openshift-operator/src/main/resources/org/kie/cloud/openshift/operator/resources/resources.properties
@@ -1,4 +1,4 @@
-kie.app.operator.deployments.url=https://raw.githubusercontent.com/kiegroup/kie-cloud-operator/${rhba.operator.branch}/deploy
+kie.app.operator.deployments.url=https://raw.githubusercontent.com/jakubschwan/kie-cloud-operator/${rhba.operator.branch}/deploy
 kie.app.operator.deployments.crd=${kie.app.operator.deployments.url}/crds/kieapp.crd.yaml
 kie.app.operator.deployments.service-account=${kie.app.operator.deployments.url}/service_account.yaml
 kie.app.operator.deployments.role=${kie.app.operator.deployments.url}/role.yaml

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <rhba.images.version.prefix>710</rhba.images.version.prefix>
     <rhba.images.branch>master</rhba.images.branch>
-    <rhba.operator.branch>master</rhba.operator.branch>
+    <rhba.operator.branch>release-v7.10.x</rhba.operator.branch>
     <rhba.operator.upgrade.from.version>7.7.1</rhba.operator.upgrade.from.version>
 
     <findbugs.failOnViolation>true</findbugs.failOnViolation>


### PR DESCRIPTION
Same workaround was applied to 7.44.x branch