### PR TITLE
upgraded to 7.51.0-SNAPSHOT

### DIFF
--- a/framework-cloud/cloud-deployment-plugin/pom.xml
+++ b/framework-cloud/cloud-deployment-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>framework-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cloud-deployment-plugin</artifactId>

--- a/framework-cloud/framework-cloud-api/pom.xml
+++ b/framework-cloud/framework-cloud-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>framework-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>framework-cloud-api</artifactId>

--- a/framework-cloud/framework-cloud-common/pom.xml
+++ b/framework-cloud/framework-cloud-common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>framework-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>framework-cloud-common</artifactId>

--- a/framework-cloud/framework-git/pom.xml
+++ b/framework-cloud/framework-git/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>framework-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>framework-git</artifactId>

--- a/framework-cloud/framework-maven/pom.xml
+++ b/framework-cloud/framework-maven/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>framework-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>framework-maven</artifactId>

--- a/framework-cloud/framework-openshift-operator/pom.xml
+++ b/framework-cloud/framework-openshift-operator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>framework-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>framework-openshift-operator</artifactId>

--- a/framework-cloud/framework-openshift-strimzi/pom.xml
+++ b/framework-cloud/framework-openshift-strimzi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>framework-cloud</artifactId>
     <groupId>org.kie.cloud</groupId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/framework-cloud/framework-openshift-templates/pom.xml
+++ b/framework-cloud/framework-openshift-templates/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>framework-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>framework-openshift-templates</artifactId>

--- a/framework-cloud/framework-openshift/pom.xml
+++ b/framework-cloud/framework-openshift/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>framework-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>framework-openshift</artifactId>

--- a/framework-cloud/pom.xml
+++ b/framework-cloud/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>kie-cloud-tests</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>framework-cloud</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie.cloud</groupId>

--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>kie-cloud-tests</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-cloud</artifactId>

--- a/test-cloud/test-cloud-common/pom.xml
+++ b/test-cloud/test-cloud-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>test-cloud</artifactId>
     <groupId>org.kie.cloud</groupId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/test-cloud/test-cloud-ha-cep/pom.xml
+++ b/test-cloud/test-cloud-ha-cep/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>test-cloud</artifactId>
     <groupId>org.kie.cloud</groupId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/test-cloud/test-cloud-optaweb/pom.xml
+++ b/test-cloud/test-cloud-optaweb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>test-cloud</artifactId>
     <groupId>org.kie.cloud</groupId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/test-cloud/test-cloud-performance/pom.xml
+++ b/test-cloud/test-cloud-performance/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>test-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-cloud-performance</artifactId>

--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>test-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-cloud-remote</artifactId>

--- a/test-cloud/test-cloud-springboot/pom.xml
+++ b/test-cloud/test-cloud-springboot/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>test-cloud</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-cloud-springboot</artifactId>

--- a/test-cloud/test-cloud-springboot/test-cloud-springboot-sample/pom.xml
+++ b/test-cloud/test-cloud-springboot/test-cloud-springboot-sample/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>test-cloud-springboot</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-cloud-springboot-sample</artifactId>

--- a/test-cloud/test-cloud-springboot/test-cloud-springboot-suite/pom.xml
+++ b/test-cloud/test-cloud-springboot/test-cloud-springboot-suite/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.cloud</groupId>
     <artifactId>test-cloud-springboot</artifactId>
-    <version>7.50.0-SNAPSHOT</version>
+    <version>7.51.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-cloud-springboot-suite</artifactId>


### PR DESCRIPTION
After update:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M1:enforce (ban-duplicated-classes) on project framework-cloud-common: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1] [log](https://gist.github.com/mbiarnes/5698798abe9d4414b4b3e5a56975365f)
