### PR TITLE
Add initSpec and initiStatus to avoid NPE in new created custom resou…

### DIFF
--- a/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/KieApp.java
+++ b/framework-cloud/framework-openshift-operator/src/main/java/org/kie/cloud/openshift/operator/model/KieApp.java
@@ -33,4 +33,13 @@ public class KieApp extends CustomResource<Spec, Status> implements Namespaced {
 
     private static final long serialVersionUID = -7608178420952152353L;
 
+    @Override
+    protected Spec initSpec() {
+        return new Spec();
+    }
+
+    @Override
+    protected Status initStatus() {
+        return new Status();
+    }
 }

--- a/framework-cloud/framework-openshift-strimzi/src/main/java/org/kie/cloud/strimzi/resources/KafkaCluster.java
+++ b/framework-cloud/framework-openshift-strimzi/src/main/java/org/kie/cloud/strimzi/resources/KafkaCluster.java
@@ -32,4 +32,13 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Singular("kafka")
 public class KafkaCluster extends CustomResource<KafkaClusterSpec, KafkaClusterStatus> implements Namespaced {
 
+    @Override
+    protected KafkaClusterSpec initSpec() {
+        return new KafkaClusterSpec();
+    }
+
+    @Override
+    protected KafkaClusterStatus initStatus() {
+        return new KafkaClusterStatus();
+    }
 }

--- a/framework-cloud/framework-openshift-strimzi/src/main/java/org/kie/cloud/strimzi/resources/KafkaTopic.java
+++ b/framework-cloud/framework-openshift-strimzi/src/main/java/org/kie/cloud/strimzi/resources/KafkaTopic.java
@@ -29,4 +29,13 @@ public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus>
 
     public static final String CLUSTER_LABEL = "strimzi.io/cluster";
 
+    @Override
+    protected KafkaTopicSpec initSpec() {
+        return new KafkaTopicSpec();
+    }
+
+    @Override
+    protected KafkaTopicStatus initStatus() {
+        return new KafkaTopicStatus();
+    }
 }


### PR DESCRIPTION
…rce objects

Without these override init methods, newly created custom resource may throw NPE, when users try to update Spec.