### PR TITLE
[7.59.x] Exclude slf4j logger from PIM dependency

### DIFF
--- a/test-cloud/test-cloud-remote/pom.xml
+++ b/test-cloud/test-cloud-remote/pom.xml
@@ -105,6 +105,10 @@
           <groupId>org.jboss.spec.javax.resource</groupId>
           <artifactId>jboss-connector-api_1.7_spec</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.slf4j</groupId>
+          <artifactId>slf4j-jboss-logmanager</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
slf4j logger from PIM override the logger configuration in kie-cloud-tests this can run on less powerful machines to exceptions like `java.lang.OutOfMemoryError: Java heap space`

cherry pick of #747 