### PR TITLE
Update prometheus version to v0.55.0

### DIFF
--- a/test-cloud/pom.xml
+++ b/test-cloud/pom.xml
@@ -46,7 +46,7 @@
     <sso.service.password>serviceUser1!</sso.service.password>
     
     <!-- Properties to configure Prometheus -->
-    <prometheus.version>v0.38.1</prometheus.version>
+    <prometheus.version>v0.55.0</prometheus.version>
 
     <kie.app.name>myapp</kie.app.name>
 


### PR DESCRIPTION
In previous versioned were also pulled images from docker hub, this may lead test to failing state due to out of limit pull from dcoker hub. In newer version this image is no longer used.