### PR TITLE
[7.67.x-blue] Exclude javax.inject to pass enforcer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,12 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
         <version>${version.org.apache.maven}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Enforcer prevents javax.inject as part of the build.